### PR TITLE
ヘッダーから各ページに画面遷移させる

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -7,7 +7,6 @@
 }
 
 a {
-  display: block;
   text-decoration: none;
 }
 

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -2,3 +2,24 @@
 //
 // The variables you want to modify
 // $font-size-root: 20px;
+.text-center {
+  margin-top: 32px;
+}
+
+a {
+  display: block;
+  text-decoration: none;
+}
+
+.mb-16 {
+  margin-bottom: 64px;
+}
+
+.top-link {
+  width: 343px;
+  height: 20px;
+}
+
+.title-text {
+  font-size: 20px;
+}

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -13,6 +13,7 @@
                     src="~/assets/images/header-icon.svg"
                     width="157.44"
                     height="28"
+                    @click="topPage"
                   />
                 </p>
               </div>
@@ -37,10 +38,20 @@
                   >
                 </div>
                 <div class="red--text line-style">
-                  <v-btn :width="120" :height="36" outlined :color="color_g"
+                  <v-btn
+                    href="/login"
+                    :width="120"
+                    :height="36"
+                    outlined
+                    :color="color_g"
                     >ログイン</v-btn
                   >
-                  <v-btn :width="120" :height="36" :color="color_r" depressed
+                  <v-btn
+                    href="/users/new"
+                    :width="120"
+                    :height="36"
+                    :color="color_r"
+                    depressed
                     >新規登録</v-btn
                   >
                 </div>
@@ -99,6 +110,7 @@
               <div class="header-style mt-3 text-caption ma-0">ゲストさん</div>
               <div class="d-flex justify-center ma-0 mt-6">
                 <v-btn
+                  href="/login"
                   :width="120"
                   :height="36"
                   :color="color_g"
@@ -106,7 +118,12 @@
                   class="mr-2"
                   >ログイン</v-btn
                 >
-                <v-btn :width="120" :height="36" :color="color_r" depressed
+                <v-btn
+                  href="/users/new"
+                  :width="120"
+                  :height="36"
+                  :color="color_r"
+                  depressed
                   >新規登録</v-btn
                 >
               </div>
@@ -265,6 +282,11 @@ export default {
       group: null,
       tile: false,
     }
+  },
+  methods: {
+    topPage() {
+      window.location.href = 'http://localhost:8000/top'
+    },
   },
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,7 +9,7 @@ export default {
   router: {
     extendRoutes(routes, resolve) {
       routes.push({
-        name: 'top',
+        name: 'toppage',
         path: '/',
         component: resolve(__dirname, 'pages/top.vue'),
       })

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -66,6 +66,7 @@ export default {
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify
   vuetify: {
     customVariables: ['~/assets/variables.scss'],
+    treeShake: true,
     theme: {
       dark: false,
       themes: {

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -40,21 +40,26 @@ export default {
   },
   methods: {
     async submit() {
-      /* this.response = await this.$http.$get('http://localhost:3000/api/users') */
-      this.response = await this.$http.$post(
-        'http://localhost:3000/api/users',
-        {
-          user: {
-            name: this.name,
-            email: this.email,
-            password: this.password,
-            password_confirmation: this.password_confirmation,
-            phone_number: this.phone_number,
-            post_code: this.post_code,
-            address: this.address,
-          },
-        }
-      )
+      try {
+        /* this.response = await this.$http.$get('http://localhost:3000/api/users') */
+        this.response = await this.$http.$post(
+          'http://localhost:3000/api/users',
+          {
+            user: {
+              name: this.name,
+              email: this.email,
+              password: this.password,
+              password_confirmation: this.password_confirmation,
+              phone_number: this.phone_number,
+              post_code: this.post_code,
+              address: this.address,
+            },
+          }
+        )
+        window.location.href = 'http://localhost:8000/users/send'
+      } catch (error) {
+        this.error = e.response.data.errors.full_messages
+      }
     },
   },
 }

--- a/pages/users/send.vue
+++ b/pages/users/send.vue
@@ -8,13 +8,11 @@
           確認メールを送付いたしました。
         </p>
       </div>
-      <a
-        href="../top"
-        class="mx-auto mt-4 text-center top-link mb-16"
-        style="color: #f06364"
-      >
-        <p>ホームケアナビトップに戻る</p>
-      </a>
+      <div class="mx-auto mt-4 text-center top-link mb-16">
+        <a href="../top" style="color: #f06364">
+          <p>ホームケアナビトップに戻る</p>
+        </a>
+      </div>
     </v-card-text>
   </v-card>
 </template>

--- a/pages/users/send.vue
+++ b/pages/users/send.vue
@@ -1,0 +1,12 @@
+<template>
+  <v-card width="750" class="mx-auto mt-2">
+    <v-card-title>
+      <h1 class="display-1">仮登録完了</h1>
+    </v-card-title>
+  </v-card>
+</template>
+<script>
+export default {
+  layout: 'application',
+}
+</script>

--- a/pages/users/send.vue
+++ b/pages/users/send.vue
@@ -1,12 +1,26 @@
 <template>
-  <v-card width="750" class="mx-auto mt-2">
-    <v-card-title>
-      <h1 class="display-1">仮登録完了</h1>
-    </v-card-title>
+  <v-card outlined width="750" class="mx-auto mt-10">
+    <v-card-text>
+      <h1 class="text-center mt-8 title-text">仮登録完了</h1>
+      <div class="text-center mt-12">
+        <p>
+          入力いただいたメールアドレスに<br />
+          確認メールを送付いたしました。
+        </p>
+      </div>
+      <a
+        href="../top"
+        class="mx-auto mt-4 text-center top-link mb-16"
+        style="color: #f06364"
+      >
+        <p>ホームケアナビトップに戻る</p>
+      </a>
+    </v-card-text>
   </v-card>
 </template>
 <script>
 export default {
   layout: 'application',
+  css: ['~/assets/variables.scss'],
 }
 </script>


### PR DESCRIPTION
ヘッダーから現在作られているページに画面遷移するようにしました。
- ログインボタン→ログイン画面
- 新規登録ボタン→新規登録画面
- ホームケアナビアイコン画像→トップ画面
