### PR TITLE
Feature/display エラーメッセージを受け取る 422エラー

### DIFF
--- a/components/ErrorMsg.vue
+++ b/components/ErrorMsg.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="my-2">
+    <v-alert
+      v-for="(msg, i) in msgs"
+      :key="i"
+      type="error"
+      width="750"
+      class="mx-auto mb-2"
+    >
+      {{ msg }}
+    </v-alert>
+  </div>
+</template>
+<script>
+import { mapGetters } from 'vuex'
+export default {
+  data() {
+    return {
+      msgs: [],
+    }
+  },
+  computed: {
+    ...mapGetters('catchErrorMsg', ['getMsg', 'emptyState']),
+  },
+  watch: {
+    emptyState() {
+      this.msgs = this.getMsg
+    },
+  },
+}
+</script>

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -190,6 +190,7 @@
       <v-container fluid class="pa-0">
         <!-- vue-routerを使用する場合 -->
         <!--<router-view></router-view>-->
+        <ErrorMsg />
         <Nuxt />
       </v-container>
     </v-main>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,6 +35,8 @@ export default {
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [],
 
+  plugins: ['~/plugins/axios.js'],
+
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,
 

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -45,6 +45,7 @@
   </v-card>
 </template>
 <script>
+import { mapActions } from 'vuex'
 export default {
   layout: 'application',
   data() {
@@ -97,6 +98,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions('catchErrorMsg', ['clearMsg']),
     async submit() {
       if (this.$refs.form.validate()) {
         this.success = true
@@ -111,10 +113,10 @@ export default {
             address: this.address,
             confirm_success_url: 'http://localhost:8000',
           })
+          this.clearMsg()
           this.$router.push('/users/send')
           return response
         } catch (error) {
-          console.log(error)
           return error
         }
       } else {

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,9 +1,9 @@
 export default function ({ $axios, store }) {
   $axios.onError((error) => {
     const code = error.response.status
-    const message = error.response.data.errors.full_messages
+    const msg = error.response.data.errors.full_messages
     if (code === 422) {
-      store.commit('message/setMessage', message)
+      store.commit('catchErrorMsg/setMsg', msg)
     }
   })
 }

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,0 +1,9 @@
+export default function ({ $axios, store }) {
+  $axios.onError((error) => {
+    const code = error.response.status
+    const message = error.response.data.errors.full_messages
+    if (code === 422) {
+      store.commit('message/setMessage', message)
+    }
+  })
+}

--- a/store/catchErrorMsg.js
+++ b/store/catchErrorMsg.js
@@ -1,0 +1,28 @@
+export const state = () => ({
+  msg: [],
+})
+export const getters = {
+  getMsg: (state) => state.msg,
+  emptyState: (state) => state.msg.lenght,
+}
+export const mutations = {
+  setMsg(state, msg) {
+    console.log(`[LOG::mutations::setMsg]::レスポンスメッセージ ${msg}`)
+    console.log(`[LOG::mutations::setMsg]::state.msg ${state.msg}`)
+    state.msg = msg
+  },
+  clearMsg(state) {
+    state.msg = ''
+    console.log(`[LOG::mutatins::clearMsg]::state.msg ${state.msg}`)
+  },
+}
+export const actions = {
+  setMsg({ commit }, msg) {
+    console.log(`[LOG::actions::setMsg]::レスポンスメッセージ ${msg}`)
+    commit('setMsg', msg)
+  },
+  clearMsg({ commit }) {
+    console.log(`[LOG::actions::clearMsg]::state.msg ${state.msg}`)
+    commit('clearMsg')
+  },
+}

--- a/store/catchErrorMsg.js
+++ b/store/catchErrorMsg.js
@@ -3,7 +3,7 @@ export const state = () => ({
 })
 export const getters = {
   getMsg: (state) => state.msg,
-  emptyState: (state) => state.msg.lenght,
+  emptyState: (state) => state.msg.length,
 }
 export const mutations = {
   setMsg(state, msg) {


### PR DESCRIPTION
## 例

[link](https://dev.classmethod.jp/articles/pull-request-template/)

## チケットへのリンク

## やったこと
1. plugins/axios.jsファイル追加
2. 1のファイル内にレスポンスのエラーをキャッチできるプログラム追加
3. 1のプログラムを読み込めるようにnuxt.config.jsに設定
4. store/catchErrorMsg.jsファイル追加
5. vuexで値を管理できるようにした

- このプルリクで何をしたのか？
新規登録時にAPIにリクエストを送った際に、エラーメッセージを受け取れるようにした.

## やらないこと
画面に表示はまだしていないこれからやる。あくまで今回はメッセージを受け取り受け取る箱を用意した

- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？
下記のようにわざとエラーが返ってくるような値をセット  
今回でいうとemailをダブらせる
```
すでにかぶっているメールアドレスでリクエストを送る
※もしかぶってなかったら、適宜追加してください
email: foobar@example.com
```
[![Image from Gyazo](https://i.gyazo.com/4572cd0b4b08f3d7cff4d60c094d325b.png)](https://gyazo.com/4572cd0b4b08f3d7cff4d60c094d325b)
下記のようにコンソール上に422エラーとログが表示されていること(メールアドレスがすでに存在しています)
[![Image from Gyazo](https://i.gyazo.com/4e48d838a193fa7bb4bdb2cfbc9db264.png)](https://gyazo.com/4e48d838a193fa7bb4bdb2cfbc9db264)
## その他
- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
422系のエラーは対応しているので、自分のタスクで再利用できそうでしたらご自由にお使いください
