### PR TITLE
build: 営業日・休業日マルバツ判定

### DIFF
--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -12,7 +12,7 @@
           <v-row class="mx-auto mt-auto max-width">
             <v-col class="office-name" cols="10">{{ office.name }}</v-col>
             <v-col cols="2">
-              <v-btn class="" fab depressed>
+              <v-btn fab depressed>
                 <v-icon>mdi-star</v-icon>
               </v-btn>
             </v-col>
@@ -59,13 +59,76 @@
                         <th>土</th>
                       </tr>
                       <tr>
-                        <td>{{ 1 }}</td>
-                        <td>{{ 1 }}</td>
-                        <td>{{ 1 }}</td>
-                        <td>{{ 1 }}</td>
-                        <td>{{ 1 }}</td>
-                        <td>{{ 1 }}</td>
-                        <td>{{ 1 }}</td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('sunday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('monday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('tuesday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('wednesday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('thursday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('friday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('saturday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -91,9 +154,10 @@
         <v-card class="sm-under-no sticky" outlined tile>
           <v-row class="mx-auto mt-auto max-width">
             <v-col class="office-name" cols="10">{{ office.name }} </v-col>
-            <v-col cols="2">
-              <v-btn class="" fab depressed>
-                <v-icon>mdi-star</v-icon>
+            <v-col class="pl-0" ols="2">
+              <v-hover></v-hover>
+              <v-btn fab depressed>
+                <v-icon large color="white">mdi-star</v-icon>
               </v-btn>
             </v-col>
             <v-col cols="12">
@@ -121,7 +185,7 @@
             <v-col cols="12">
               <v-btn x-large block depressed color="error"> WEB予約する </v-btn>
             </v-col>
-            <v-col cols="12">
+            <v-col class="py-1" cols="12">
               <div class="holiday-pc">営業日</div>
             </v-col>
             <v-col>
@@ -138,18 +202,83 @@
                       <th>土</th>
                     </tr>
                     <tr>
-                      <td>{{ 1 }}</td>
-                      <td>{{ 1 }}</td>
-                      <td>{{ 1 }}</td>
-                      <td>{{ 1 }}</td>
-                      <td>{{ 1 }}</td>
-                      <td>{{ 1 }}</td>
-                      <td>{{ 1 }}</td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('sunday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('monday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('tuesday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('wednesday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('thursday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('friday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('saturday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <div class="mt-4 mb-4 holiday-detail">営業日の説明が入ります</div>
+              <div class="mt-4 mb-4 holiday-detail">
+                {{ office.business_day_detail }}
+              </div>
             </v-col>
           </v-row>
         </v-card>

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -155,7 +155,6 @@
           <v-row class="mx-auto mt-auto max-width">
             <v-col class="office-name" cols="10">{{ office.name }} </v-col>
             <v-col class="pl-0" ols="2">
-              <v-hover></v-hover>
               <v-btn fab depressed>
                 <v-icon large color="white">mdi-star</v-icon>
               </v-btn>


### PR DESCRIPTION
## チケットへのリンク

- http://localhost:8000/offices/1

## やったこと

- 事業所の営業日・休業日を◯✕判定し表示させる
営業日は◯、休業日なら✕

## やらないこと

- なし

## できるようになること（ユーザ目線）

- 各事業所の営業日・休業日が確認できる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- https://github.com/koki-takishita/home-care-navi-api/pull/36 の手順を実行する

- API側で`rails db:seed`で事業所のデータを生成する
- Postmanで事業所の休業日を確認する（画像だと日曜と水曜が休み）
https://www.postman.com/
`http://localhost:3000/api/offices/1`
![image](https://user-images.githubusercontent.com/34031637/168943559-c35e4eff-860e-4739-b3ac-eb310707dcdc.png)

- フロントで事業所詳細画面にアクセスし、反映されてるか確認
http://localhost:8000/offices/1
![image](https://user-images.githubusercontent.com/34031637/168943814-b8adba45-2447-4b10-9da6-2c8b3f09b87b.png)

## その他
