### PR TITLE
Feature/login form validate ログインフォームバリテーション

### DIFF
--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -176,7 +176,7 @@
           </v-list-item>
         </v-card>
 
-        <v-list nav dense class="pa-0" v-if="$auth.loggedIn">
+        <v-list v-if="$auth.loggedIn" nav dense class="pa-0">
           <v-list-item-group v-model="group">
             <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
               <v-list-item-title>

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -4,15 +4,27 @@
       <h1 class="display-1">ログイン</h1>
     </v-card-title>
     <v-card-text>
-      <v-form>
-        <v-text-field v-model="loginInfo.email" label="メールアドレス" />
+      <v-form v-model="loginInfo.valid">
+        <v-text-field
+          v-model="loginInfo.email"
+          label="メールアドレス"
+          :rules="[formValidates.required, formValidates.email]"
+        />
         <v-text-field
           v-model="loginInfo.password"
           label="パスワード"
           type="password"
+          :rules="[
+            formValidates.required,
+            formValidates.password,
+            formValidates.typeCheckString,
+          ]"
         />
         <v-card-actions>
-          <v-btn class="info" @click.prevent="$login(loginInfo)"
+          <v-btn
+            class="info"
+            :disabled="!loginInfo.valid"
+            @click.prevent="$login(loginInfo)"
             >ログイン</v-btn
           >
         </v-card-actions>
@@ -29,6 +41,23 @@ export default {
       loginInfo: {
         email: '',
         password: '',
+        valid: false,
+      },
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        email: (value) => {
+          const format =
+            // eslint-disable-next-line no-control-regex
+            /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
+          return format.test(value) || '正しいメールアドレスを入力してください'
+        },
+        password: (value) =>
+          (value.length >= 8 && value.length <= 16) ||
+          '8文字以上16文字未満で入力してください',
+        typeCheckString: (value) => {
+          const format = /^[a-zA-Z0-9]+$/g
+          return format.test(value) || '入力できるのは半角英数字のみです'
+        },
       },
     }
   },

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -142,16 +142,6 @@
               @click="sign_up()"
               >新規登録</v-btn
             >
-            <v-btn
-              class="error pa-0 ma-0 text-h6 d-block d-sm-none"
-              block
-              :disabled="!form.valid"
-              max-width="520"
-              min-width="343"
-              height="48"
-              @click="sign_up()"
-              >新規登録</v-btn
-            >
           </v-card-actions>
         </v-form>
       </div>

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -31,6 +31,8 @@ function authError422and401(store, error) {
     error422(store, error)
   } else if (code === 401) {
     error401(store, error)
+  } else if (code === 500) {
+    error500(store)
   }
 }
 
@@ -42,6 +44,12 @@ function error422(store, error) {
 
 function error401(store, error) {
   const msg = error.response.data.errors
+  store.commit('catchErrorMsg/clearMsg')
+  store.commit('catchErrorMsg/setMsg', msg)
+}
+
+function error500(store) {
+  const msg = ['サーバー側のエラーです。しばらく経ってから再度お願いします。']
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
 }


### PR DESCRIPTION
## やったこと
1. ログインフォームバリテーション
2. 500エラー対応

## やらないこと

スタイリング

## できるようになること（ユーザ目線）

バリテーションを突破しないと、ボタンが押せない
サーバー側のエラーを表示できる、つまりマイグレーションエラーが起きててもフロント側で検知できる

## できなくなること（ユーザ目線）

なし

## 動作確認
### 【FRONT】git操作 front
- fetch
```ruby
$ git fetch
```
- checkout
```ruby
$ git checkout origin/feature/login-form-validate
```
### 【API】git 操作 api 最新の`develop`
- fetch
```ruby
$ git fetch
```
- checkout
```ruby
$ git checkout origin/develop
```
### docker-compouse
- restart
```ruby
$ docker-compose restart
```

手順
1. 下記のURLアクセス
```ruby
http://localhost:8000/users/login
```
2. 空で警告が出る(email・password)
3. フォーマットで警告が出る(email)

## 画像(PCおそすぎてloom用意できませんでした)
- 空で警告
[![Image from Gyazo](https://i.gyazo.com/589cf0838473fbeb55d6a0730fd7e04e.png)](https://gyazo.com/589cf0838473fbeb55d6a0730fd7e04e)
- フォーマット警告
[![Image from Gyazo](https://i.gyazo.com/a8ee5da87ee6b2ab07a2b8a1228c5489.png)](https://gyazo.com/a8ee5da87ee6b2ab07a2b8a1228c5489)
- バリテーション突破したらボタン押せるようになる
[![Image from Gyazo](https://i.gyazo.com/7f6d93fb97ab0e9f2539aaa2658b3177.png)](https://gyazo.com/7f6d93fb97ab0e9f2539aaa2658b3177)