### PR TITLE
Feature/login form style

### DIFF
--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -176,7 +176,7 @@
           </v-list-item>
         </v-card>
 
-        <v-list nav dense class="pa-0" v-if="$auth.loggedIn">
+        <v-list v-if="$auth.loggedIn" nav dense class="pa-0">
           <v-list-item-group v-model="group">
             <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
               <v-list-item-title>

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -23,7 +23,7 @@
       </p>
     </div>
 
-    <div class="pa-4 pt-0">
+    <div class="pa-4 pt-0 mt-6">
       <div class="form-wrapper mx-auto">
         <v-form v-model="loginInfo.valid">
           <label class="font-color-gray font-weight-black text-caption"
@@ -33,8 +33,9 @@
               :rules="[formValidates.required, formValidates.email]"
               outlined
               dense
+              height="44"
               placeholder="homecarenavi@mail.com"
-              class="font-weight-regular"
+              class="font-weight-regular mt-2"
           /></label>
 
           <label class="font-color-gray font-weight-black text-caption"
@@ -48,8 +49,9 @@
               ]"
               outlined
               dense
+              height="44"
               placeholder="半角英数字8文字以上"
-              class="font-weight-regular"
+              class="font-weight-regular mt-2"
               type="password"
           /></label>
 

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -4,15 +4,27 @@
       <h1 class="display-1">ログイン</h1>
     </v-card-title>
     <v-card-text>
-      <v-form>
-        <v-text-field v-model="loginInfo.email" label="メールアドレス" />
+      <v-form v-model="loginInfo.valid">
+        <v-text-field
+          v-model="loginInfo.email"
+          label="メールアドレス"
+          :rules="[formValidates.required, formValidates.email]"
+        />
         <v-text-field
           v-model="loginInfo.password"
           label="パスワード"
           type="password"
+          :rules="[
+            formValidates.required,
+            formValidates.password,
+            formValidates.typeCheckString,
+          ]"
         />
         <v-card-actions>
-          <v-btn class="info" @click.prevent="$login(loginInfo)"
+          <v-btn
+            class="info"
+            :disabled="!loginInfo.valid"
+            @click.prevent="$login(loginInfo)"
             >ログイン</v-btn
           >
         </v-card-actions>
@@ -29,6 +41,23 @@ export default {
       loginInfo: {
         email: '',
         password: '',
+        valid: false,
+      },
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        email: (value) => {
+          const format =
+            // eslint-disable-next-line no-control-regex
+            /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
+          return format.test(value) || '正しいメールアドレスを入力してください'
+        },
+        password: (value) =>
+          (value.length >= 8 && value.length <= 16) ||
+          '8文字以上16文字未満で入力してください',
+        typeCheckString: (value) => {
+          const format = /^[a-zA-Z0-9]+$/g
+          return format.test(value) || '入力できるのは半角英数字のみです'
+        },
       },
     }
   },

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -1,35 +1,107 @@
 <template>
-  <v-card width="750" class="mx-auto mt-2">
-    <v-card-title>
-      <h1 class="display-1">ログイン</h1>
-    </v-card-title>
-    <v-card-text>
-      <v-form v-model="loginInfo.valid">
-        <v-text-field
-          v-model="loginInfo.email"
-          label="メールアドレス"
-          :rules="[formValidates.required, formValidates.email]"
-        />
-        <v-text-field
-          v-model="loginInfo.password"
-          label="パスワード"
-          type="password"
-          :rules="[
-            formValidates.required,
-            formValidates.password,
-            formValidates.typeCheckString,
-          ]"
-        />
-        <v-card-actions>
-          <v-btn
-            class="info"
-            :disabled="!loginInfo.valid"
-            @click.prevent="$login(loginInfo)"
-            >ログイン</v-btn
-          >
-        </v-card-actions>
-      </v-form>
-    </v-card-text>
+  <v-card
+    min-width="375"
+    max-width="750"
+    min-height="400"
+    max-height="487"
+    class="mx-auto my-2"
+  >
+    <div class="px-4 pt-4 d-none d-sm-block">
+      <p class="mb-0 text-right">
+        <NuxtLink to="#" class="text-overline text-decoration-none link-color"
+          >ケアマネージャの方はこちら</NuxtLink
+        >
+      </p>
+      <h6 class="display-1 text-center text-h6 font-weight-black">ログイン</h6>
+    </div>
+    <div class="px-4 pt-4 d-flex justify-space-between d-sm-none">
+      <h6 class="display-1 text-center text-h6 font-weight-black">ログイン</h6>
+      <p class="mb-0 text-right">
+        <NuxtLink to="#" class="text-overline text-decoration-none link-color"
+          >ケアマネージャーの方はこちら</NuxtLink
+        >
+      </p>
+    </div>
+
+    <div class="pa-4 pt-0">
+      <div class="form-wrapper mx-auto">
+        <v-form v-model="loginInfo.valid">
+          <label class="font-color-gray font-weight-black text-caption"
+            >メールアドレス
+            <v-text-field
+              v-model="loginInfo.email"
+              :rules="[formValidates.required, formValidates.email]"
+              outlined
+              dense
+              placeholder="homecarenavi@mail.com"
+              class="font-weight-regular"
+          /></label>
+
+          <label class="font-color-gray font-weight-black text-caption"
+            >パスワード
+            <v-text-field
+              v-model="loginInfo.password"
+              :rules="[
+                formValidates.required,
+                formValidates.password,
+                formValidates.typeCheckString,
+              ]"
+              outlined
+              dense
+              placeholder="半角英数字8文字以上"
+              class="font-weight-regular"
+              type="password"
+          /></label>
+
+          <p class="ma-0 text-right mt-n3 mb-7">
+            <NuxtLink
+              to="#"
+              class="text-overline text-decoration-none font-color-gray"
+              >パスワードを忘れた</NuxtLink
+            >
+          </p>
+
+          <v-card-actions class="pa-0">
+            <v-btn
+              class="error pa-0 text-h6 d-none d-sm-block"
+              block
+              :disabled="!loginInfo.valid"
+              max-width="520"
+              min-width="343"
+              height="60"
+              @click.prevent="$login(loginInfo)"
+              >ログイン</v-btn
+            >
+
+            <v-btn
+              class="error pa-0 ma-0 text-h6 d-block d-sm-none"
+              block
+              :disabled="!loginInfo.valid"
+              max-width="520"
+              min-width="343"
+              height="48"
+              @click.prevent="$login(loginInfo)"
+              >ログイン</v-btn
+            >
+          </v-card-actions>
+          <p class="ma-0 pb-7 text-center d-block d-sm-none">
+            <NuxtLink
+              to="/users/new"
+              class="text-overline text-decoration-none link-color"
+              >新規登録はこちら</NuxtLink
+            >
+          </p>
+
+          <p class="ma-0 pb-16 text-center d-none d-sm-block">
+            <NuxtLink
+              to="/users/new"
+              class="text-overline text-decoration-none link-color"
+              >新規登録はこちら</NuxtLink
+            >
+          </p>
+        </v-form>
+      </div>
+    </div>
   </v-card>
 </template>
 
@@ -63,3 +135,22 @@ export default {
   },
 }
 </script>
+<style scoped>
+.link-color {
+  color: #f06364;
+}
+
+.form-wrapper {
+  max-width: 520px;
+}
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+::v-deep input::placeholder {
+  color: #d9dede !important;
+}
+.font-color-gray {
+  color: #6d7570;
+}
+</style>

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -2,7 +2,9 @@
   <v-card width="750" class="mx-auto mb-2">
     <div class="px-4 pt-4 d-none d-sm-block">
       <p class="mb-0 text-right">
-        <NuxtLink to="#" class="text-overline text-decoration-none link-color"
+        <NuxtLink
+          to="/users/login"
+          class="text-overline text-decoration-none link-color"
           >ログインはこちら</NuxtLink
         >
       </p>
@@ -11,7 +13,9 @@
     <div class="px-4 pt-4 d-flex justify-space-between d-sm-none">
       <h6 class="display-1 text-center text-h6 font-weight-black">新規登録</h6>
       <p class="mb-0 text-right">
-        <NuxtLink to="#" class="text-overline text-decoration-none link-color"
+        <NuxtLink
+          to="/users/login"
+          class="text-overline text-decoration-none link-color"
           >ログインはこちら</NuxtLink
         >
       </p>
@@ -139,6 +143,16 @@
               max-width="520"
               min-width="343"
               height="60"
+              @click="sign_up()"
+              >新規登録</v-btn
+            >
+            <v-btn
+              class="error pa-0 ma-0 text-h6 d-block d-sm-none"
+              block
+              :disabled="!form.valid"
+              max-width="520"
+              min-width="343"
+              height="48"
               @click="sign_up()"
               >新規登録</v-btn
             >

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -142,16 +142,6 @@
               @click="sign_up()"
               >新規登録</v-btn
             >
-            <v-btn
-              class="error pa-0 ma-0 text-h6 d-block d-sm-none"
-              block
-              :disabled="!form.valid"
-              max-width="520"
-              min-width="343"
-              height="48"
-              @click="sign_up()"
-              >新規登録</v-btn
-            >
           </v-card-actions>
         </v-form>
       </div>

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,19 +1,21 @@
 export default function ({ $axios, store }) {
+  // TODO onResponseError onRequestErrorで分けたい
   $axios.onError((error) => {
     networkError(store, error)
     authError422and401(store, error)
     // console.log("[LOG]::onError")
   })
 
-  $axios.onRequest((config) => {
-    setAuthInfoToHeader(config)
-    // console.log("[LOG]::onRequest")
-  })
-
   $axios.onResponse((response) => {
     store.commit('catchErrorMsg/clearMsg')
     setAuthInfoToLocalStorage(response)
     // console.log("[LOG]::onResponse")
+  })
+
+  $axios.onRequest((config) => {
+    if (config.url === '/login') {
+      setAuthInfoToHeader(config)
+    }
   })
 }
 
@@ -36,6 +38,13 @@ function authError422and401(store, error) {
   }
 }
 
+function setAuthInfoToHeader(config) {
+  config.headers.client = window.localStorage.client
+  config.headers['access-token'] = window.localStorage.getItem('access-token')
+  config.headers.uid = window.localStorage.uid
+  config.headers.expiry = window.localStorage.expiry
+}
+
 function error422(store, error) {
   const msg = error.response.data.errors.full_messages
   store.commit('catchErrorMsg/clearMsg')
@@ -52,13 +61,6 @@ function error500(store) {
   const msg = ['サーバー側のエラーです。しばらく経ってから再度お願いします。']
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
-}
-
-function setAuthInfoToHeader(config) {
-  config.headers.client = window.localStorage.client
-  config.headers['access-token'] = window.localStorage.getItem('access-token')
-  config.headers.uid = window.localStorage.uid
-  config.headers.expiry = window.localStorage.expiry
 }
 
 function setAuthInfoToLocalStorage(response) {

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -31,6 +31,8 @@ function authError422and401(store, error) {
     error422(store, error)
   } else if (code === 401) {
     error401(store, error)
+  } else if (code === 500) {
+    error500(store)
   }
 }
 
@@ -42,6 +44,12 @@ function error422(store, error) {
 
 function error401(store, error) {
   const msg = error.response.data.errors
+  store.commit('catchErrorMsg/clearMsg')
+  store.commit('catchErrorMsg/setMsg', msg)
+}
+
+function error500(store) {
+  const msg = ['サーバー側のエラーです。しばらく経ってから再度お願いします。']
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
 }

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -1,6 +1,13 @@
-export default function ({ $auth, redirect, store }, inject) {
+export default function ({ $auth, redirect, store, $axios }, inject) {
   inject('login', (loginInfo) => {
     login(loginInfo)
+  })
+
+  $axios.onRequest((config) => {
+    console.log(config)
+    if (config.url === '/login') {
+      setAuthInfoToHeader(config)
+    }
   })
 
   async function login(loginInfo) {
@@ -16,4 +23,11 @@ export default function ({ $auth, redirect, store }, inject) {
       return error
     }
   }
+}
+
+function setAuthInfoToHeader(config) {
+  config.headers.client = window.localStorage.client
+  config.headers['access-token'] = window.localStorage.getItem('access-token')
+  config.headers.uid = window.localStorage.uid
+  config.headers.expiry = window.localStorage.expiry
 }


### PR DESCRIPTION
## やったこと

1. login formのスタイルを整えた

## やらないこと

- 下記のリンクは機能しない
```ruby
ケアマネージャーの方はこちら
パスワードを忘れた
```
- `パスワードを忘れた` の位置
```ruby
もっと上にできるが、上にしてしまうとバリテーションのメッセージ領域とかぶる
かぶってしまうと、クリックできなくなる
z-indexで一番先頭にしてみたが、効果なし
```
- [参考サイトでは下記のようにメッセージ自体を消して対処していた](http://www.home-care-navi.com/signin)
[![Image from Gyazo](https://i.gyazo.com/14cd1036c259d1a9d6976afceb0b4a06.png)](https://gyazo.com/14cd1036c259d1a9d6976afceb0b4a06)
見栄えを優先すると、このパターンだが個人的にはメッセージ合ったほうがいい気がするけどどうですか？
[![Image from Gyazo](https://i.gyazo.com/9555bf6e44c04fcfc1475b1d8cb113aa.png)](https://gyazo.com/9555bf6e44c04fcfc1475b1d8cb113aa)

## できるようになること（ユーザ目線）

見栄えが良くなる

## できなくなること（ユーザ目線）

なし

## 動作確認
1. スマホとPCレイアウトが崩れないことを確認お願いします
### 【FRONT】git操作 front
- fetch
```ruby
$ git fetch
```
- checkout
```ruby
$ git checkout origin/feature/login-form-style
```
### 【API】git 操作 api 最新の`develop`
- fetch
```ruby
$ git fetch
```
- checkout
```ruby
$ git checkout origin/develop
```
### docker-compouse
- restart
```ruby
$ docker-compose restart
```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
