### PR TITLE
fix: エンドポイント修正

### DIFF
--- a/components/ErrorMsg.vue
+++ b/components/ErrorMsg.vue
@@ -6,6 +6,8 @@
       :type="type"
       max-width="750"
       min-width="350"
+      v-model="alert"
+      dismissible
       class="mx-auto mb-2"
     >
       {{ msg }}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -76,8 +76,8 @@ export default {
           property: false,
         },
         endpoints: {
-          login: { url: '/users/sign_in', method: 'post' },
-          logout: { url: '/users/sign_out', method: 'delete' },
+          login: { url: '/login', method: 'post' },
+          logout: { url: '/logout', method: 'delete' },
           user: false,
         },
       },

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -9,7 +9,7 @@
     <div class="px-4 pt-4 d-none d-sm-block">
       <p class="mb-0 text-right">
         <NuxtLink to="#" class="text-overline text-decoration-none link-color"
-          >ケアマネージャの方はこちら</NuxtLink
+          >ケアマネージャーの方はこちら</NuxtLink
         >
       </p>
       <h6 class="display-1 text-center text-h6 font-weight-black">ログイン</h6>


### PR DESCRIPTION
## やったこと

1. loginエンドポイント修正
2. logoutエンドポイント修正

```ruby
# login
api/users/sign_in → api/login
# logout
api/users/sign_out → api/logout
```
## やらないこと

今確認したら、nuxt-linkでもフラッシュ消えないなー、これなんとかします.今週中は無理だけど
ログイン成功後、利用規約とか、プライバシーポリシーにアクセスするとそのまま

追記 閉じるボタン実装しました
追記 前回の「ケアマネージャ」のtypo修正文

## できるようになること（ユーザ目線）

API側修正後のエンドポイントに対応

## できなくなること（ユーザ目線）

なし

## 動作確認
- 前提条件
[このプルリクエストが`develop`にマージされていること or APIはこのブランチで試す](https://github.com/koki-takishita/home-care-navi-api/pull/41)
- 手順
1. ログイン画面からパラメーターセット
2. ログインボタンおす
3. ログイン成功すること確認
```ruby
docker-compose restart
```
[手順動画](https://www.loom.com/share/0d7c6155073848d489af9c9592ef7f34)

## その他