### PR TITLE
build: create top page layout

### DIFF
--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -43,12 +43,12 @@ export default {
       'setPrefectures',
       'setCities',
       'clearCities',
-      'clearTowns',
+      'clearCurrentPrefecture',
     ]),
     fetchAreas(chooseArea) {
       this.setPrefectures(chooseArea)
       this.clearCities()
-      this.clearTowns()
+      this.clearCurrentPrefecture()
     },
     fetchAreaToTokyo() {
       this.setPrefectures('関東')

--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="w-390">
+    <v-card min-height="324" max-width="375" class="pa-4">
+      <v-btn block color="error" min-height="48" outlined>
+        現在地から探す
+      </v-btn>
+      <div class="mt-3 d-flex justify-space-between flex-wrap w-343 h-232">
+        <v-card
+          v-for="(area, i) in areas"
+          :key="i"
+          hover
+          outlined
+          max-height="72"
+          min-width="109"
+          @click="fetchAreas(area)"
+        >
+          {{ area }}
+        </v-card>
+      </div>
+    </v-card>
+  </div>
+</template>
+<script>
+import { mapActions } from 'vuex'
+export default {
+  data() {
+    return {
+      areas: [
+        '関東',
+        '関西',
+        '東海',
+        '北海道',
+        '東北',
+        '甲信越北陸',
+        '中国',
+        '四国',
+        '九州沖縄',
+      ],
+    }
+  },
+  methods: {
+    ...mapActions('areaData', [
+      'setPrefectures',
+      'setCities',
+      'clearCities',
+      'clearTowns',
+    ]),
+    fetchAreas(chooseArea) {
+      this.setPrefectures(chooseArea)
+      this.clearCities()
+      this.clearTowns()
+    },
+    fetchAreaToTokyo() {
+      this.setPrefectures('関東')
+      this.setCities('東京都')
+    },
+  },
+  mounted() {
+    this.fetchAreaToTokyo()
+  },
+}
+</script>
+<style scoped>
+.w-390 {
+  min-width: 390px;
+}
+
+.w-343 {
+  width: 342px;
+}
+
+.h-232 {
+  height: 232px;
+}
+</style>

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -15,37 +15,50 @@
     </v-list>
     <div class="d-flex ml-n3">
       <v-btn min-width="80" min-height="40" class="mr-2">クリア</v-btn>
-      <v-btn min-width="160" min-height="40" color="error" @click="fetchTowns()"
+      <v-btn
+        min-width="160"
+        min-height="40"
+        color="error"
+        @click="SearchForOfficesChosenByAddress"
         >検索する</v-btn
       >
     </div>
   </v-card>
 </template>
 <script>
-import { mapActions, mapGetters } from 'vuex'
+import { mapGetters } from 'vuex'
 export default {
   data() {
     return {
       cities: [],
-      selectedCity: '',
+      chooseCity: '',
+      choosePrefecture: '',
     }
   },
   watch: {
     getCities() {
       this.cities = this.getCities
     },
+    getCurrentPrefecture() {
+      this.choosePrefecture = this.getCurrentPrefecture
+    },
   },
   computed: {
-    ...mapGetters('areaData', ['getCities']),
+    ...mapGetters('areaData', ['getCities', 'getCurrentPrefecture']),
   },
   methods: {
-    ...mapActions('areaData', ['setTowns']),
-    fetchTowns() {
-      const chooseCity = this.selectedCity
-      this.setTowns(chooseCity)
-    },
     checkItem(chooseItem) {
-      this.selectedCity = chooseItem
+      this.chooseCity = chooseItem
+    },
+    async SearchForOfficesChosenByAddress() {
+      try {
+        const prefecture = encodeURI(this.choosePrefecture)
+        const city = encodeURI(this.chooseCity)
+        const requestUrl = `offices?prefecture=${prefecture}&city=${city}`
+        await this.$axios.$get(requestUrl)
+      } catch (error) {
+        return error
+      }
     },
   },
 }

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-card
+    min-height="324"
+    max-width="268"
+    class="pa-6 pt-5 pb-3 d-flex flex-column"
+  >
+    <v-list class="overflow-auto mb-auto" max-height="240">
+      <v-list-item
+        v-for="(city, i) in cities"
+        :key="i"
+        @click="checkItem(city.city)"
+      >
+        {{ city.city }}
+      </v-list-item>
+    </v-list>
+    <div class="d-flex ml-n3">
+      <v-btn min-width="80" min-height="40" class="mr-2">クリア</v-btn>
+      <v-btn min-width="160" min-height="40" color="error" @click="fetchTowns()"
+        >検索する</v-btn
+      >
+    </div>
+  </v-card>
+</template>
+<script>
+import { mapActions, mapGetters } from 'vuex'
+export default {
+  data() {
+    return {
+      cities: [],
+      selectedCity: '',
+    }
+  },
+  watch: {
+    getCities() {
+      this.cities = this.getCities
+    },
+  },
+  computed: {
+    ...mapGetters('areaData', ['getCities']),
+  },
+  methods: {
+    ...mapActions('areaData', ['setTowns']),
+    fetchTowns() {
+      const chooseCity = this.selectedCity
+      this.setTowns(chooseCity)
+    },
+    checkItem(chooseItem) {
+      this.selectedCity = chooseItem
+    },
+  },
+}
+</script>

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -30,10 +30,9 @@ export default {
     ...mapGetters('areaData', ['getPrefectures']),
   },
   methods: {
-    ...mapActions('areaData', ['setCities', 'clearTowns']),
+    ...mapActions('areaData', ['setCities']),
     fetchCities(choosePrefecture) {
       this.setCities(choosePrefecture)
-      this.clearTowns()
     },
   },
 }

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="w-283">
+    <v-card min-height="324" max-width="268" class="pa-6 pt-5">
+      <v-list class="overflow-auto" max-height="270">
+        <v-list-item
+          v-for="(prefecture, i) in prefectures"
+          :key="i"
+          @click="fetchCities(prefecture)"
+        >
+          {{ prefecture }}
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </div>
+</template>
+<script>
+import { mapActions, mapGetters } from 'vuex'
+export default {
+  data() {
+    return {
+      prefectures: [],
+    }
+  },
+  watch: {
+    getPrefectures() {
+      this.prefectures = this.getPrefectures
+    },
+  },
+  computed: {
+    ...mapGetters('areaData', ['getPrefectures']),
+  },
+  methods: {
+    ...mapActions('areaData', ['setCities', 'clearTowns']),
+    fetchCities(choosePrefecture) {
+      this.setCities(choosePrefecture)
+      this.clearTowns()
+    },
+  },
+}
+</script>
+<style scoped>
+.w-283 {
+  min-width: 283px;
+}
+</style>

--- a/components/ErrorMsg.vue
+++ b/components/ErrorMsg.vue
@@ -3,10 +3,10 @@
     <v-alert
       v-for="(msg, i) in msgs"
       :key="i"
+      v-model="alert"
       :type="type"
       max-width="750"
       min-width="350"
-      v-model="alert"
       dismissible
       class="mx-auto mb-2"
     >

--- a/components/SubTitle.vue
+++ b/components/SubTitle.vue
@@ -1,0 +1,8 @@
+<template>
+  <v-card max-width="990" min-height="245" class="mx-auto">
+    <p>サブタイトル</p>
+  </v-card>
+</template>
+<script>
+export default {}
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,7 +15,6 @@ export default {
       })
     },
   },
-
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
     titleTemplate: '%s - front',
@@ -35,7 +34,7 @@ export default {
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [],
 
-  plugins: ['~/plugins/axios.js'],
+  plugins: ['~/plugins/axios.js', '~/plugins/apiToRequestOfAddress.js'],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -1,6 +1,15 @@
 <template>
-  <div>
-    <h1>ここはTOPページです</h1>
+  <div class="w-990 mx-auto mt-n2 mb-2">
+    <SubTitle />
+    <div class="mx-auto h-74">
+      <!--親要素の下に配置-->
+      <p>エリアから探す</p>
+    </div>
+    <div class="d-flex justify-space-between">
+      <ChooseAreaCard />
+      <ChoosePrefectureCard />
+      <ChooseCityCard />
+    </div>
   </div>
 </template>
 <script>
@@ -8,3 +17,12 @@ export default {
   layout: 'application',
 }
 </script>
+<style scoped>
+.w-990 {
+  max-width: 990px;
+}
+
+.h-74 {
+  min-height: 74px;
+}
+</style>

--- a/plugins/apiToRequestOfAddress.js
+++ b/plugins/apiToRequestOfAddress.js
@@ -1,0 +1,11 @@
+export default function ({ $axios }, inject) {
+  const apiToAddress = $axios.create({
+    headers: {
+      common: {
+        Accept: 'text/plain, */*',
+      },
+    },
+  })
+  apiToAddress.setBaseURL('https://geoapi.heartrails.com/api/')
+  inject('apiToAddressJson', apiToAddress)
+}

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -104,7 +104,7 @@ export const actions = {
       )
       const fetchCities = res.response.location
       commit('setCities', fetchCities)
-      commit('setCurrentPrefecture')
+      commit('setCurrentPrefecture', choosePrefecture)
     } catch (error) {
       return error
     }

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -1,0 +1,123 @@
+export const state = () => ({
+  prefectures: [],
+  cities: [],
+  towns: [],
+})
+
+const areas = {
+  hokaido: ['北海道'],
+  touhoku: ['青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県'],
+  koushinetsuHokuriku: [
+    '新潟県',
+    '富山県',
+    '石川県',
+    '福井県',
+    '山梨県',
+    '長野県',
+  ],
+  kanto: [
+    '東京都',
+    '神奈川県',
+    '埼玉県',
+    '千葉県',
+    '茨城県',
+    '栃木県',
+    '群馬県',
+  ],
+  kansai: ['滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県'],
+  tokai: ['岐阜県', '静岡県', '愛知県', '三重県'],
+  tyugoku: ['鳥取県', '島根県', '岡山県', '広島県', '山口県'],
+  shikoku: ['徳島県', '香川県', '愛媛県', '高知県'],
+  kyusyuOkinawa: [
+    '福岡県',
+    '佐賀県',
+    '長崎県',
+    '熊本県',
+    '大分県',
+    '宮崎県',
+    '鹿児島県',
+    '沖縄',
+  ],
+}
+
+const requestMethods = {
+  cities: 'json?method=getCities&prefecture=',
+  towns: 'json?method=getTowns&city=',
+}
+
+export const getters = {
+  getPrefectures: (state) => state.prefectures,
+  getCities: (state) => state.cities,
+}
+
+export const mutations = {
+  setPrefectures(state, prefectures) {
+    state.prefectures = prefectures
+  },
+  setCities(state, cities) {
+    state.cities = cities
+  },
+  clearCities(state) {
+    state.cities = []
+  },
+  setTowns(state, towns) {
+    state.towns = towns
+  },
+  clearTowns(state) {
+    state.towns = []
+  },
+}
+
+export const actions = {
+  setPrefectures({ commit }, chooseArea) {
+    if (chooseArea === '北海道') {
+      commit('setPrefectures', areas.hokaido)
+    } else if (chooseArea === '東北') {
+      commit('setPrefectures', areas.touhoku)
+    } else if (chooseArea === '甲信越北陸') {
+      commit('setPrefectures', areas.koushinetsuHokuriku)
+    } else if (chooseArea === '関東') {
+      commit('setPrefectures', areas.kanto)
+    } else if (chooseArea === '関西') {
+      commit('setPrefectures', areas.kansai)
+    } else if (chooseArea === '東海') {
+      commit('setPrefectures', areas.tokai)
+    } else if (chooseArea === '中国') {
+      commit('setPrefectures', areas.tyugoku)
+    } else if (chooseArea === '四国') {
+      commit('setPrefectures', areas.shikoku)
+    } else if (chooseArea === '九州沖縄') {
+      commit('setPrefectures', areas.kyusyuOkinawa)
+    }
+  },
+  async setCities({ commit }, chooseCity) {
+    try {
+      const encodeString = encodeURI(chooseCity)
+      const res = await this.$apiToAddressJson.$get(
+        requestMethods.cities + encodeString
+      )
+      const fetchCities = res.response.location
+      commit('setCities', fetchCities)
+    } catch (error) {
+      return error
+    }
+  },
+  clearCities({ commit }) {
+    commit('clearCities')
+  },
+  async setTowns({ commit }, chooseTown) {
+    try {
+      const encodeString = encodeURI(chooseTown)
+      const res = await this.$apiToAddressJson.$get(
+        requestMethods.towns + encodeString
+      )
+      const fetchTowns = res.response.location
+      commit('setTowns', fetchTowns)
+    } catch (error) {
+      return error
+    }
+  },
+  clearTowns({ commit }) {
+    commit('clearTowns')
+  },
+}

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -96,15 +96,15 @@ export const actions = {
   clearCurrentPrefecture({ commit }) {
     commit('clearCurrentPrefecture')
   },
-  async setCities({ commit }, chooseCity) {
+  async setCities({ commit }, choosePrefecture) {
     try {
-      const encodeString = encodeURI(chooseCity)
+      const encodeString = encodeURI(choosePrefecture)
       const res = await this.$apiToAddressJson.$get(
         requestMethods.cities + encodeString
       )
       const fetchCities = res.response.location
       commit('setCities', fetchCities)
-      commit('setCurrentPrefecture', chooseCity)
+      commit('setCurrentPrefecture')
     } catch (error) {
       return error
     }

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -1,9 +1,3 @@
-export const state = () => ({
-  prefectures: [],
-  cities: [],
-  towns: [],
-})
-
 const areas = {
   hokaido: ['北海道'],
   touhoku: ['青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県'],
@@ -42,11 +36,17 @@ const areas = {
 
 const requestMethods = {
   cities: 'json?method=getCities&prefecture=',
-  towns: 'json?method=getTowns&city=',
 }
+
+export const state = () => ({
+  prefectures: [],
+  currentPrefecture: '',
+  cities: [],
+})
 
 export const getters = {
   getPrefectures: (state) => state.prefectures,
+  getCurrentPrefecture: (state) => state.currentPrefecture,
   getCities: (state) => state.cities,
 }
 
@@ -54,17 +54,17 @@ export const mutations = {
   setPrefectures(state, prefectures) {
     state.prefectures = prefectures
   },
+  setCurrentPrefecture(state, prefecture) {
+    state.currentPrefecture = prefecture
+  },
+  clearCurrentPrefecture(state) {
+    state.currentPrefecture = ''
+  },
   setCities(state, cities) {
     state.cities = cities
   },
   clearCities(state) {
     state.cities = []
-  },
-  setTowns(state, towns) {
-    state.towns = towns
-  },
-  clearTowns(state) {
-    state.towns = []
   },
 }
 
@@ -90,6 +90,12 @@ export const actions = {
       commit('setPrefectures', areas.kyusyuOkinawa)
     }
   },
+  setCurrentPrefecture({ commit }, prefecture) {
+    commit('setCurrentPrefecture', prefecture)
+  },
+  clearCurrentPrefecture({ commit }) {
+    commit('clearCurrentPrefecture')
+  },
   async setCities({ commit }, chooseCity) {
     try {
       const encodeString = encodeURI(chooseCity)
@@ -98,26 +104,12 @@ export const actions = {
       )
       const fetchCities = res.response.location
       commit('setCities', fetchCities)
+      commit('setCurrentPrefecture', chooseCity)
     } catch (error) {
       return error
     }
   },
   clearCities({ commit }) {
     commit('clearCities')
-  },
-  async setTowns({ commit }, chooseTown) {
-    try {
-      const encodeString = encodeURI(chooseTown)
-      const res = await this.$apiToAddressJson.$get(
-        requestMethods.towns + encodeString
-      )
-      const fetchTowns = res.response.location
-      commit('setTowns', fetchTowns)
-    } catch (error) {
-      return error
-    }
-  },
-  clearTowns({ commit }) {
-    commit('clearTowns')
   },
 }


### PR DESCRIPTION
## やったこと

## 1. ページを`ロード`または`リロード`すると、下記のように`関東`・`東京都`でデータがセットされる
- 言葉定義
**ロード: 初回アクセス、ページ遷移**
**リロード: ロードしたあとページを`再読込`する**

- 画面URL

```ruby
http://localhost:8000/top
```
[![Image from Gyazo](https://i.gyazo.com/c54d62f4992848deb2f5d1721ca6e024.png)](https://gyazo.com/c54d62f4992848deb2f5d1721ca6e024)

## 2. エリアをクリックするとエリアに応じた都道府県がセットされ、表示される
[![Image from Gyazo](https://i.gyazo.com/03bf0e4451cfd0c27644ca8b39a2eccf.gif)](https://gyazo.com/03bf0e4451cfd0c27644ca8b39a2eccf)

## 3. 都道府県をクリックすると、都道府県に応じた市町村がセットされ、表示される
[![Image from Gyazo](https://i.gyazo.com/42297ece6d0cdcf8186fd50d4fef61f6.gif)](https://gyazo.com/42297ece6d0cdcf8186fd50d4fef61f6)

## やらないこと

1. スタイリング

## できるようになること（ユーザ目線）

1. 事業所を探す際に、エリアを画面から選択できるようになる

## できなくなること（ユーザ目線）

なし

## 動作確認

**APIはfetchしなくて良い**
### 【FRONT】git操作 front
- fetch
```ruby
$ git fetch
```
- checkout
```ruby
$ git checkout origin/feature/topPage
```

1. `やったこと`の`1〜3`の手順と同じ動作になること
2. 適当にエリア、都道府県選択
3. リロードする
4. 下記のように選択した内容はリセットされ、関東、東京でセットされたものが表示される
[![Image from Gyazo](https://i.gyazo.com/19afc02a3036ef3cd49b7349aef56602.gif)](https://gyazo.com/19afc02a3036ef3cd49b7349aef56602)