### PR TITLE
Feature/スタッフ登録画面

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,3 @@
-## 例
-
-[link](https://dev.classmethod.jp/articles/pull-request-template/)
-
-## チケットへのリンク
-
-- https://example.com
-
 ## やったこと
 
 - このプルリクで何をしたのか？

--- a/components/ErrorMsg.vue
+++ b/components/ErrorMsg.vue
@@ -3,10 +3,10 @@
     <v-alert
       v-for="(msg, i) in msgs"
       :key="i"
+      v-model="alert"
       :type="type"
       max-width="750"
       min-width="350"
-      v-model="alert"
       dismissible
       class="mx-auto mb-2"
     >

--- a/pages/specialists/office/_id/staffs/new.vue
+++ b/pages/specialists/office/_id/staffs/new.vue
@@ -18,7 +18,7 @@
             <v-file-input
               v-model="image"
               :rules="[formValidates.fileSizeCheck]"
-              accept="image/png, image/jpeg, image/jpg"
+              accept="image/*"
               prepend-icon="mdi-camera"
               label="画像をアップロードする"
               class="mt-6 mr-4 ml-3"
@@ -98,7 +98,7 @@ export default {
         fileSizeCheck: (value) =>
           !value ||
           value.size <= 10000000 ||
-          'ファイルサイズは10MB以下でアップロードしてください',
+          '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
           value.length <= 31 || '30文字以下で入力してください',
         kanaCheck: (value) => {

--- a/pages/specialists/office/_id/staffs/new.vue
+++ b/pages/specialists/office/_id/staffs/new.vue
@@ -1,0 +1,162 @@
+<template>
+  <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
+    <p class="mb-0 text-left">
+      <NuxtLink
+        to=""
+        class="text-overline text-decoration-none link-color sm-under-no"
+        >＜ スタッフ情報一覧にもどる</NuxtLink
+      >
+    </p>
+    <v-card class="mx-auto mb-2 p-0">
+      <v-col cols="12"><h3>スタッフ登録</h3></v-col>
+      <v-form v-model="valid">
+        <v-col md="10">
+          <v-row>
+            <v-avatar size="100" color="grey lighten-3" class="ml-3">
+              <v-icon size="70" color="white">mdi-account</v-icon>
+            </v-avatar>
+            <v-file-input
+              v-model="image"
+              :rules="[formValidates.fileSizeCheck]"
+              accept="image/png, image/jpeg, image/jpg"
+              prepend-icon="mdi-camera"
+              label="画像をアップロードする"
+              class="mt-6 mr-4 ml-3"
+            >
+            </v-file-input>
+          </v-row>
+        </v-col>
+        <v-col cols="12">
+          <label class="font-color-gray font-weight-black text-caption"
+            >スタッフ名
+            <v-text-field
+              v-model="name"
+              :rules="[formValidates.required, formValidates.nameCountCheck]"
+              class="mt-2 font-weight-regular"
+              placeholder="田中 太郎"
+              outlined
+              dense
+              height="44"
+          /></label>
+          <label class="font-color-gray font-weight-black text-caption"
+            >スタッフ名(ふりがな)
+            <v-text-field
+              v-model="kana"
+              :rules="[
+                formValidates.required,
+                formValidates.nameCountCheck,
+                formValidates.kanaCheck,
+              ]"
+              class="mt-2 font-weight-regular"
+              placeholder="たなか たろう"
+              outlined
+              dense
+              height="44"
+          /></label>
+          <label class="font-color-gray font-weight-black text-caption"
+            >スタッフ紹介文
+            <v-textarea
+              v-model="introduction"
+              :rules="[formValidates.introductionCountCheck]"
+              class="mt-2 font-weight-regular"
+              height="80"
+              outlined
+              dense
+            >
+            </v-textarea
+          ></label>
+          <v-btn
+            x-large
+            block
+            depressed
+            :disabled="!valid"
+            color="warning"
+            @click="send"
+          >
+            登録する
+          </v-btn>
+          <p class="mb-0 text-center">
+            <NuxtLink
+              to=""
+              class="text-overline text-decoration-none link-color"
+              >もどる</NuxtLink
+            >
+          </p>
+        </v-col>
+      </v-form>
+    </v-card>
+  </v-col>
+</template>
+
+<script>
+export default {
+  layout: 'application_specialists',
+  data() {
+    return {
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        fileSizeCheck: (value) =>
+          !value ||
+          value.size <= 10000000 ||
+          'ファイルサイズは10MB以下でアップロードしてください',
+        nameCountCheck: (value) =>
+          value.length <= 31 || '30文字以下で入力してください',
+        kanaCheck: (value) => {
+          const format = /^[ぁ-んー　 ]*$/ // eslint-disable-line
+          return format.test(value) || 'ひらがなで入力してください'
+        },
+        introductionCountCheck: (value) =>
+          value.length <= 81 || '80文字以下で入力してください',
+      },
+      office_id: this.$route.params.id,
+      name: '',
+      kana: '',
+      introduction: '',
+      image: null,
+      valid: false,
+    }
+  },
+  methods: {
+    async send() {
+      const id = this.office_id
+      const params = new FormData()
+      params.append('office_id', this.office_id)
+      params.append('name', this.name)
+      params.append('kana', this.kana)
+      params.append('introduction', this.introduction)
+      if (this.image !== null) {
+        params.append('image', this.image)
+      }
+      try {
+        // `specialists/offices/${id}/staffs`
+        await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        })
+      } catch (error) {
+        return error
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.link-color {
+  color: #ee7b1a;
+}
+
+.font-color-gray {
+  color: #6d7570;
+}
+
+.max-width {
+  max-width: 750px;
+}
+
+@media screen and (max-width: 959px) {
+  /* sm以下で表示しない */
+  .sm-under-no {
+    display: none;
+  }
+}
+</style>

--- a/pages/specialists/office/_id/staffs/new.vue
+++ b/pages/specialists/office/_id/staffs/new.vue
@@ -1,31 +1,30 @@
 <template>
-  <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
-    <p class="mb-0 text-left">
+  <div>
+    <p class="mb-0 text-left link-width mx-auto">
       <NuxtLink
         to=""
         class="text-overline text-decoration-none link-color sm-under-no"
         >＜ スタッフ情報一覧にもどる</NuxtLink
       >
     </p>
-    <v-card class="mx-auto mb-2 p-0">
+    <v-card class="mx-auto mb-2 p-0" width="750">
       <v-col cols="12"><h3>スタッフ登録</h3></v-col>
       <v-form v-model="valid">
-        <v-col md="10">
-          <v-row>
-            <v-avatar size="100" color="grey lighten-3" class="ml-3">
-              <v-icon size="70" color="white">mdi-account</v-icon>
-            </v-avatar>
-            <v-file-input
-              v-model="image"
-              :rules="[formValidates.fileSizeCheck]"
-              accept="image/*"
-              prepend-icon="mdi-camera"
-              label="画像をアップロードする"
-              class="mt-6 mr-4 ml-3"
-            >
-            </v-file-input>
-          </v-row>
-        </v-col>
+        <v-row>
+          <v-avatar size="100" color="grey lighten-3" class="ml-6 my-4">
+            <v-icon size="70" color="white">mdi-account</v-icon>
+          </v-avatar>
+          <v-file-input
+            v-model="image"
+            truncate-length="20"
+            :rules="[formValidates.fileSizeCheck]"
+            accept="image/*"
+            prepend-icon="mdi-camera"
+            label="画像をアップロードする"
+            class="mt-15 ml-3 image-form"
+          >
+          </v-file-input>
+        </v-row>
         <v-col cols="12">
           <label class="font-color-gray font-weight-black text-caption"
             >スタッフ名
@@ -85,7 +84,7 @@
         </v-col>
       </v-form>
     </v-card>
-  </v-col>
+  </div>
 </template>
 
 <script>
@@ -149,8 +148,8 @@ export default {
   color: #6d7570;
 }
 
-.max-width {
-  max-width: 750px;
+.link-width {
+  width: 750px;
 }
 
 @media screen and (max-width: 959px) {
@@ -158,5 +157,9 @@ export default {
   .sm-under-no {
     display: none;
   }
+}
+/* stylelint-disable */
+.image-form >>> .v-input__slot {
+  width: 200px;
 }
 </style>

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -4,7 +4,7 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
   })
 
   $axios.onRequest((config) => {
-    console.log(config)
+    // console.log(config)
     if (config.url === '/login') {
       setAuthInfoToHeader(config)
     }


### PR DESCRIPTION
## やったこと

- スタッフ登録画面作成
  - PC・SPレイアウト作成
  - 入力フォームバリデーション（画像であれば、画像ファイルのどの拡張子でもアップできます。動画やPDFなどの関係ないファイルは選択できないようにしています）
  - 登録ボタンクリック時にPOSTリクエスト送信（バリデーション突破しないと押せない）
  - スタイル調整

## やらないこと

- 登録・もどるボタンクリック時のページ遷移（スタッフ一覧画面に遷移するので、スタッフ一覧画面作成時にやります。）
- ケアマネの保有する事業所以外のURLのIDにアクセス・保存できない設定（今週のスプリントでは対応しません）
- アイコンにアップした画像のプレビュー的な機能（対応予定なし）

## できるようになること（ユーザ目線）

- スタッフ登録

## できなくなること（ユーザ目線）

- なし

## 動作確認

- API側でfetch後、checkout
```
git fetch
```
```
git checkout origin/feature/スタッフ登録-画像あり
``` 

- フロント側でfetch後、checkout
```
git fetch
```
```
git checkout origin/feature/スタッフ登録
```
- [http://localhost:8000/specialists/office/1/staffs/new](http://localhost:8000/specialists/office/1/staffs/new)にアクセス
  - URLの~~office/1←この数字がスタッフに紐づく事業所のIDになります 
- 動画を参照し、実際にフォームを入力してもらいレイアウトのスタイル・バリデーションなどをチェックしてもらう
```
Postman　リクエスト先URLコピペ用
http://localhost:3000/api/specialists/offices/1/staffs
```
[loom スタッフ登録画面〜Postman確認まで](https://www.loom.com/share/297a1ea8bfab4947b97835eec63689b0)

## サンプル画像はこちらからダウンロードしてお使いください

- 10.5MBの画像（10MB超えアップロード時エラーの確認用）

![10 5MB](https://user-images.githubusercontent.com/34031637/170165949-32bb0193-f6df-465f-bf8a-3259c875fa40.png)

- 若い男性の画像（25KB）

![youngman_25](https://user-images.githubusercontent.com/34031637/170166550-a8cdd39e-30ef-4c5d-a959-fb16b52b7a2a.png)

## その他

- [PC-スタッフ情報編集画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/5999d7d2-a785-41e7-a4b5-080fddbae2e5/)
- [SP-スタッフ情報編集画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/7dba0299-4d1f-4775-9a8d-e07fe6ece7c5/)
- [画面一覧書](https://docs.google.com/spreadsheets/d/1zBUODbQx18IKoKiNmmvuOu6PvCYvTNH5-YTG1JIAcOQ/edit#gid=334611837)
- 画面一覧のスタッフ登録画面のURLが一覧画面と一緒になっていて、かぶるのはまずいので、staffs/newとしました。
- 画像の拡張子の制限を緩めるのと、画像アップロードフォームの長さを修正したのちWIP外します。
- https://github.com/koki-takishita/home-care-navi-api/pull/46
