### PR TITLE
fix: フォーム修正とバリデーション

### DIFF
--- a/pages/contacts/new.vue
+++ b/pages/contacts/new.vue
@@ -1,48 +1,83 @@
 <template>
-  <v-card width="750" class="mx-auto my-6">
-    <v-card-title>
-      <h4 class="display-1">お問い合わせ</h4>
-    </v-card-title>
+  <v-card width="750" class="mx-auto mb-2">
+    <div class="px-4 pt-4 d-sm-block">
+      <h4 class="display-1 text-center text-h6 font-weight-black">
+        お問い合わせ
+      </h4>
+    </div>
     <v-card-text>
-      <v-form solo>
-        <p>お名前</p>
-        <v-text-field
-          v-model="name"
-          filled
-          required="required"
-          placeholder="田中太郎"
-          solo
-          label="田中太郎"
-        />
-        <p>返信用メールアドレス</p>
-        <v-text-field
-          v-model="email"
-          required="required"
-          placeholder="homecarenavi@mail.com"
-          solo
-          label="homecarenavi@mail.com"
-        />
-        <p>利用者区分</p>
-        <v-row>
-          <v-col class="d-flex" cols="12" sm="4">
-            <v-select :items="items" label="ユーザー"></v-select>
-          </v-col>
-        </v-row>
-        <p>お問い合わせ内容</p>
-        <v-textarea
-          outlined
-          required="required"
-          placeholder="入力してください"
-          solo
-          label="入力してください"
-          type="password"
-        />
-        <v-card-actions>
-          <v-btn to="/contacts/confirm" class="info" block large>
-            この内容で問い合わせる
-          </v-btn>
-        </v-card-actions>
-      </v-form>
+      <div class="form-wrapper mx-auto">
+        <v-form v-model="form.valid">
+          <div class="set-width-343">
+            <label class="font-color-gray font-weight-black text-caption"
+              >お名前
+              <v-text-field
+                id="name"
+                v-model="form.name"
+                class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
+                placeholder="田中 太郎"
+                outlined
+                dense
+                height="44"
+                :rules="[formValidates.required]"
+            /></label>
+          </div>
+
+          <div class="mt-n-2">
+            <label class="font-color-gray font-weight-black text-caption"
+              >返信用メールアドレス
+              <v-text-field
+                v-model="form.email"
+                class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
+                outlined
+                dense
+                placeholder="homecarenavi@mail.com"
+                type="email"
+                height="44"
+                :rules="[formValidates.required, formValidates.email]"
+            /></label>
+          </div>
+
+          <label class="font-color-gray font-weight-black text-caption">
+            利用者区分
+            <v-row class="set-width-343">
+              <v-col>
+                <v-select
+                  :items="items"
+                  dense
+                  placeholder="選択してください"
+                  :rules="[formValidates.required]"
+                ></v-select>
+              </v-col>
+            </v-row>
+          </label>
+          <label class="font-color-gray font-weight-black text-caption"
+            >お問い合わせ内容
+            <v-textarea
+              outlined
+              required="required"
+              placeholder="入力してください"
+              solo
+              type="password"
+              :rules="[formValidates.required]"
+            />
+          </label>
+
+          <v-card-actions class="pa-0">
+            <v-btn
+              to="/contacts/confirm"
+              class="error text-h6 block"
+              block
+              :disabled="!form.valid"
+              max-width="520"
+              min-width="343"
+              height="60"
+              @click="contact()"
+              >この内容で問い合わせる</v-btn
+            >
+          </v-card-actions>
+        </v-form>
+      </div>
     </v-card-text>
   </v-card>
 </template>
@@ -50,27 +85,83 @@
 <script>
 export default {
   layout: 'application',
-  data: () => ({
-    items: ['ユーザー', 'ケアマネージャー', '事業所', 'その他'],
-  }),
-  methods: {
-    contact() {
-      this.$router.push('/contacts/comfirm')
-    },
+  data() {
+    return {
+      items: ['ユーザー', 'ケアマネージャー', '事業所', 'その他'],
+      form: {
+        name: '',
+        email: '',
+        types: '',
+        content: '',
+        valid: false,
+      },
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        typeCheckString: (value) => {
+          const format = /^[a-zA-Z0-9]+$/g
+          return format.test(value) || '入力できるのは半角英数字のみです'
+        },
+        email: (value) => {
+          const format =
+            // eslint-disable-next-line no-control-regex
+            /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
+          return format.test(value) || '正しいメールアドレスを入力してください'
+        },
+        methods: {
+          contact() {
+            this.$router.push('/contacts/comfirm')
+          },
+        },
+      },
+    }
   },
 }
-
-/*      methods: {
-    async submit() {
-      /* this.response = await this.$http.$get('http://localhost:3000/api/users') */
-
-/*      this.response = await this.$http.$post(
-        'http://localhost:3000/api/contacts',
-        {
-          user: {
-            name: this.name,
-            email: this.email,
-          },
-        }
-        */
 </script>
+
+<style scoped>
+.form-wrapper {
+  max-width: 520px;
+}
+
+.px-px-115 {
+  padding: 0 115px;
+}
+
+.set-width-343 {
+  width: 343px;
+}
+
+.set-height-44 {
+  height: 44px;
+}
+
+/* stylelint-disable */
+.post-form >>> fieldset {
+  width: 107px;
+}
+
+.post-form >>> .v-text-field__slot {
+  max-width: 82px;
+}
+
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+
+.mt-n-2 {
+  margin-top: -2px;
+}
+
+.font-color-gray {
+  color: #6d7570;
+}
+
+::v-deep input::placeholder {
+  color: #d9dede !important;
+}
+
+.set-max-width-520 {
+  max-width: 520px;
+  min-width: 343px;
+}
+</style>


### PR DESCRIPTION
## やったこと

-  問い合わせ入力フォームのレイアウト修正
（名前やメールアドレスのサイズ感などは新規登録ページと合わせました）
-レスポンシブ対応
- バリデーション設定　

## やらないこと

- 確認ページで入力項目の情報が表示される機能

## できるようになること（ユーザ目線）

- 問い合わせの内容が正しく設定できる
- スマホでもページ崩れずに見れる

## できなくなること（ユーザ目線）

-入力不備がある状態での問い合わせ送信ができなくなる

## 動作確認
・ローカル上の問い合わせページで確認
http://localhost:8000/contacts/new

参照；
https://gyazo.com/549dc7adef44d576e540cbf98f42a22b

・XD画面と比較
https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/27f935f4-cd8f-4787-89f5-29a7d0799ee1/

・レスポンシブ対応
・レイアウトの確認
・空だとエラー文が表示される
・バリデーション条件ごとにエラー文が表示される
・入力項目を満たさないと確認ボタンが押せない

## その他
- XDと違うところアリ　（分かりやすさと見やすさで変更しました）
・名前フォームのサイズ
・利用者区分フォームの種類とサイズ
・利用者区分のラベルの文章（ユーザー ⇨ 選択してください）