### PR TITLE
市町村カード複数対応・スタイル調整

### DIFF
--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="w-390">
-    <v-card min-height="324" max-width="375" class="pa-4">
+    <v-card min-height="324" max-width="375" class="pa-4" outlined>
       <v-btn block color="error" min-height="48" outlined>
-        現在地から探す
+        <v-icon small>mdi-map-marker</v-icon>
+        <span class="font-weight-black ml-2">現在地から探す</span>
       </v-btn>
       <div class="mt-3 d-flex justify-space-between flex-wrap w-343 h-232">
         <v-card
@@ -12,9 +13,12 @@
           outlined
           max-height="72"
           min-width="109"
+          class="d-flex align-center"
           @click="fetchAreas(area)"
         >
-          {{ area }}
+          <v-card-text class="text-center font-weight-black">
+            {{ area }}
+          </v-card-text>
         </v-card>
       </div>
     </v-card>

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -6,25 +6,31 @@
     class="pa-6 pt-5 pb-3 d-flex flex-column"
   >
     <v-list class="overflow-auto mb-auto" max-height="240">
-      <v-list-item-group>
-        <v-list-item v-for="(city, i) in cities" :key="i" dense>
-          <v-checkbox
-            v-model="chooseItems"
-            class="mt-n1"
-            multiple
-            dense
-            :value="cities[i].city"
-            hide-details
-          >
-          </v-checkbox>
-          <v-list-item-content class="text-button pa-0">
-            {{ city.city }}
-          </v-list-item-content>
-        </v-list-item>
-      </v-list-item-group>
+      <v-list-item v-for="(city, i) in cities" :key="i" dense class="">
+        <v-checkbox
+          v-model="chooseItems"
+          class="mt-n1"
+          multiple
+          dense
+          :value="cities[i].city"
+          hide-details
+        >
+        </v-checkbox>
+        <v-list-item-content class="text-button pa-0 ml-n2">
+          {{ city.city }}
+        </v-list-item-content>
+        <v-icon block>mdi-chevron-right</v-icon>
+      </v-list-item>
     </v-list>
     <div class="d-flex ml-n3">
-      <v-btn min-width="80" min-height="40" class="mr-2" outlined depressed>
+      <v-btn
+        min-width="80"
+        min-height="40"
+        class="mr-2"
+        outlined
+        depressed
+        @click="clearChoosenItems()"
+      >
         <span class="color-red">クリア</span></v-btn
       >
       <v-btn
@@ -79,6 +85,9 @@ export default {
       } catch (error) {
         return error
       }
+    },
+    clearChoosenItems() {
+      this.chooseItems = []
     },
   },
 }

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -2,26 +2,37 @@
   <v-card
     min-height="324"
     max-width="268"
+    outlined
     class="pa-6 pt-5 pb-3 d-flex flex-column"
   >
     <v-list class="overflow-auto mb-auto" max-height="240">
-      <v-list-item-group multiple>
+      <v-list-item-group>
         <v-list-item v-for="(city, i) in cities" :key="i" dense>
           <v-checkbox
             v-model="chooseItems"
+            class="mt-n1"
+            multiple
             dense
             :value="cities[i].city"
-          ></v-checkbox>
-          {{ city.city }}
+            hide-details
+          >
+          </v-checkbox>
+          <v-list-item-content class="text-button pa-0">
+            {{ city.city }}
+          </v-list-item-content>
         </v-list-item>
       </v-list-item-group>
     </v-list>
     <div class="d-flex ml-n3">
-      <v-btn min-width="80" min-height="40" class="mr-2">クリア</v-btn>
+      <v-btn min-width="80" min-height="40" class="mr-2" outlined depressed>
+        <span class="color-red">クリア</span></v-btn
+      >
       <v-btn
         min-width="160"
         min-height="40"
         color="error"
+        depressed
+        class="font-weight-black"
         @click="SearchForOfficesChosenByAddress"
         >検索する</v-btn
       >
@@ -72,3 +83,8 @@ export default {
   },
 }
 </script>
+<style>
+.color-red {
+  color: red;
+}
+</style>

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -55,6 +55,7 @@ export default {
     async SearchForOfficesChosenByAddress() {
       if (this.chooseItems.length === 0) {
         alert('市町村を１つ以上選択してください。')
+        return
       }
       try {
         const prefecture = encodeURI(this.choosePrefecture)

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -5,13 +5,16 @@
     class="pa-6 pt-5 pb-3 d-flex flex-column"
   >
     <v-list class="overflow-auto mb-auto" max-height="240">
-      <v-list-item
-        v-for="(city, i) in cities"
-        :key="i"
-        @click="checkItem(city.city)"
-      >
-        {{ city.city }}
-      </v-list-item>
+      <v-list-item-group multiple>
+        <v-list-item v-for="(city, i) in cities" :key="i" dense>
+          <v-checkbox
+            v-model="chooseItems"
+            dense
+            :value="cities[i].city"
+          ></v-checkbox>
+          {{ city.city }}
+        </v-list-item>
+      </v-list-item-group>
     </v-list>
     <div class="d-flex ml-n3">
       <v-btn min-width="80" min-height="40" class="mr-2">クリア</v-btn>
@@ -31,13 +34,15 @@ export default {
   data() {
     return {
       cities: [],
-      chooseCity: '',
+      // TODO 複数対応
       choosePrefecture: '',
+      chooseItems: [],
     }
   },
   watch: {
     getCities() {
       this.cities = this.getCities
+      this.chooseItems = []
     },
     getCurrentPrefecture() {
       this.choosePrefecture = this.getCurrentPrefecture
@@ -47,14 +52,17 @@ export default {
     ...mapGetters('areaData', ['getCities', 'getCurrentPrefecture']),
   },
   methods: {
-    checkItem(chooseItem) {
-      this.chooseCity = chooseItem
-    },
     async SearchForOfficesChosenByAddress() {
+      if (this.chooseItems.length === 0) {
+        alert('市町村を１つ以上選択してください。')
+      }
       try {
         const prefecture = encodeURI(this.choosePrefecture)
-        const city = encodeURI(this.chooseCity)
-        const requestUrl = `offices?prefecture=${prefecture}&city=${city}`
+        const arry = []
+        Array.prototype.forEach.call(Object(this.chooseItems), (value) => {
+          arry.push(encodeURI(value))
+        })
+        const requestUrl = `offices?prefecture=${prefecture}&city=${arry}`
         await this.$axios.$get(requestUrl)
       } catch (error) {
         return error

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -7,8 +7,8 @@
           :key="i"
           @click="fetchCities(prefecture)"
         >
-          <v-list-item-content>
-            {{ prefecture }}
+          <v-list-item-content class="text-button">
+            <span class="">{{ prefecture }}</span>
           </v-list-item-content>
           <v-list-item-icon>
             <v-icon block>mdi-chevron-right</v-icon>

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="w-283">
-    <v-card min-height="324" max-width="268" class="pa-6 pt-5">
-      <v-list class="overflow-auto" max-height="270">
+    <v-card min-height="324" max-width="268" class="pa-6 pt-5" outlined>
+      <v-list dense class="overflow-auto" max-height="270">
         <v-list-item
           v-for="(prefecture, i) in prefectures"
           :key="i"
           @click="fetchCities(prefecture)"
         >
-          {{ prefecture }}
+          <v-list-item-content>
+            {{ prefecture }}
+          </v-list-item-content>
+          <v-list-item-icon>
+            <v-icon block>mdi-chevron-right</v-icon>
+          </v-list-item-icon>
         </v-list-item>
       </v-list>
     </v-card>

--- a/components/SubTitle.vue
+++ b/components/SubTitle.vue
@@ -1,8 +1,42 @@
 <template>
-  <v-card max-width="990" min-height="245" class="mx-auto">
-    <p>サブタイトル</p>
+  <v-card outlined max-width="990" min-height="245" class="mx-auto">
+    <div class="text-center set-color font-weight-black mt-12">
+      <p class="fs-28 mb-2">安心して介護をお願いしたいから。</p>
+      <p class="text-caption mb-0">
+        ホームケアナビは、ケアマネージャーの検索ができるサービスです。
+      </p>
+    </div>
+    <div class="mt-6 max-width-720 mx-auto">
+      <v-text-field
+        placeholder="事業所名、市町村など"
+        append-icon="mdi-magnify"
+        outlined
+        rounded
+      ></v-text-field>
+    </div>
   </v-card>
 </template>
 <script>
 export default {}
 </script>
+<style scoped>
+.fs-28 {
+  font-size: 28px;
+}
+
+.max-width-720 {
+  max-width: 720px;
+}
+
+.set-color {
+  color: #6d7570;
+}
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+
+::v-deep input::placeholder {
+  color: #d9dede !important;
+}
+</style>

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="w-990 mx-auto mt-n2 mb-2">
     <SubTitle />
-    <div class="mx-auto h-74">
-      <!--親要素の下に配置-->
-      <p>エリアから探す</p>
+    <div class="mx-auto h-74 d-flex align-end">
+      <p class="color-dark-gray font-weight-black text-body-1">
+        エリアから探す
+      </p>
     </div>
     <div class="d-flex justify-space-between">
       <ChooseAreaCard />
@@ -24,5 +25,9 @@ export default {
 
 .h-74 {
   min-height: 74px;
+}
+
+.color-dark-gray {
+  color: #2e3331;
 }
 </style>


### PR DESCRIPTION
## やったこと

1. 市町村カード複数対応
2. 全体スタイリング

## やらないこと

1. スマホ対応
2. 機能に直接関係ない細かいスタイリング 下記に示す(後回しにする理由は時間がかかるから、issueに書いて後日余裕があれば対応します)
**下に上げたやつで優先度高そうだったら対応します**
- 三角形
- クリック後のアクティブになるやつ
- チェックボックスの色・大きさ(XDとくらべ小さい・色も若干違う)
- チェックボックスはラベルを設定していないため、チェックボックスを直接クリックしないとチェックされない(例えば千代田区をクリックしてもチェックがされない)

## できるようになること（ユーザ目線）

1. 住所を複数選択できる

## できなくなること（ユーザ目線）

なし

## 動作確認

### 【FRONT】git操作 front
- fetch
```ruby
$ git fetch
```
- checkout
```ruby
$ git checkout origin/feature/topPage
```

## 1. 市町村複数選択できる
[![Image from Gyazo](https://i.gyazo.com/716fc1766888bacc4e766d7d7019854a.gif)](https://gyazo.com/716fc1766888bacc4e766d7d7019854a)
## 2. クリアで選択解除できる
[![Image from Gyazo](https://i.gyazo.com/cd68ba9963070a3154ea9f8d91813130.gif)](https://gyazo.com/cd68ba9963070a3154ea9f8d91813130)
## 3. リクエストに選択した県・市町村が含まれている
[![Image from Gyazo](https://i.gyazo.com/7b5ce76fe423a38b9ab03c7c0dbfe3f3.gif)](https://gyazo.com/7b5ce76fe423a38b9ab03c7c0dbfe3f3)
## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
