### PR TITLE
ケアマネージャーログイン画面レイアウト

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -124,7 +124,7 @@
                 >
                 <v-btn
                   color="warning"
-                  href="new"
+                  href="/specialists/users/new"
                   :width="120"
                   :height="36"
                   depressed
@@ -135,7 +135,7 @@
                 <NuxtLink
                   to="/users/login"
                   class="link-style text-overline mr-5 text-decoration-none mr-5"
-                  >利用者の方はこちら</NuxtLink
+                  >一般の方はこちら</NuxtLink
                 >
               </div>
             </v-list-item-content>

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -1,10 +1,163 @@
 <template>
-  <h1>ログイン画面です</h1>
+  <v-card
+    min-width="375"
+    max-width="750"
+    min-height="400"
+    max-height="487"
+    class="mx-auto my-2"
+  >
+    <div class="px-4 pt-4 d-none d-sm-block">
+      <p class="mb-0 text-right">
+        <NuxtLink
+          to="/users/login"
+          class="text-overline text-decoration-none link-color"
+          >一般の方はこちら</NuxtLink
+        >
+      </p>
+      <h6 class="display-1 text-center text-h6 font-weight-black">ログイン</h6>
+    </div>
+    <div class="px-4 pt-4 d-flex justify-space-between d-sm-none">
+      <h6 class="display-1 text-center text-h6 font-weight-black">ログイン</h6>
+      <p class="mb-0 text-right">
+        <NuxtLink
+          to="/users/login"
+          class="text-overline text-decoration-none link-color"
+          >一般の方はこちら</NuxtLink
+        >
+      </p>
+    </div>
+
+    <div class="pa-4 pt-0 mt-6">
+      <div class="form-wrapper mx-auto">
+        <v-form v-model="loginInfo.valid">
+          <label class="font-color-gray font-weight-black text-caption"
+            >メールアドレス
+            <v-text-field
+              v-model="loginInfo.email"
+              :rules="[formValidates.required, formValidates.email]"
+              outlined
+              dense
+              height="44"
+              placeholder="homecarenavi@mail.com"
+              class="font-weight-regular mt-2"
+          /></label>
+
+          <label class="font-color-gray font-weight-black text-caption"
+            >パスワード
+            <v-text-field
+              v-model="loginInfo.password"
+              :rules="[
+                formValidates.required,
+                formValidates.password,
+                formValidates.typeCheckString,
+              ]"
+              outlined
+              dense
+              height="44"
+              placeholder="半角英数字8文字以上"
+              class="font-weight-regular mt-2"
+              type="password"
+          /></label>
+
+          <p class="ma-0 text-right mt-n3 mb-7">
+            <NuxtLink
+              to="#"
+              class="text-overline text-decoration-none font-color-gray"
+              >パスワードを忘れた</NuxtLink
+            >
+          </p>
+
+          <v-card-actions class="pa-0">
+            <v-btn
+              class="warning pa-0 text-h6 d-none d-sm-block"
+              block
+              :disabled="!loginInfo.valid"
+              max-width="520"
+              min-width="343"
+              height="60"
+              @click.prevent="$login(loginInfo)"
+              >ログイン</v-btn
+            >
+
+            <v-btn
+              class="warning pa-0 ma-0 text-h6 d-block d-sm-none"
+              block
+              :disabled="!loginInfo.valid"
+              max-width="520"
+              min-width="343"
+              height="48"
+              @click.prevent="$login(loginInfo)"
+              >ログイン</v-btn
+            >
+          </v-card-actions>
+          <p class="ma-0 pb-7 text-center d-block d-sm-none">
+            <NuxtLink
+              to="/specialists/users/new"
+              class="text-overline text-decoration-none link-color"
+              >新規登録はこちら</NuxtLink
+            >
+          </p>
+
+          <p class="ma-0 pb-16 text-center d-none d-sm-block">
+            <NuxtLink
+              to="/specialists/users/new"
+              class="text-overline text-decoration-none link-color"
+              >新規登録はこちら</NuxtLink
+            >
+          </p>
+        </v-form>
+      </div>
+    </div>
+  </v-card>
 </template>
 
 <script>
 export default {
   layout: 'application_specialists',
-  css: ['~/assets/variables.scss'],
+  data() {
+    return {
+      loginInfo: {
+        email: '',
+        password: '',
+        redirecttUrl: '/specialists/users/new',
+        valid: false,
+      },
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        email: (value) => {
+          const format =
+            // eslint-disable-next-line no-control-regex
+            /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
+          return format.test(value) || '正しいメールアドレスを入力してください'
+        },
+        password: (value) =>
+          (value.length >= 8 && value.length <= 16) ||
+          '8文字以上16文字未満で入力してください',
+        typeCheckString: (value) => {
+          const format = /^[a-zA-Z0-9]+$/g
+          return format.test(value) || '入力できるのは半角英数字のみです'
+        },
+      },
+    }
+  },
 }
 </script>
+<style scoped>
+.link-color {
+  color: #f09c3c;
+}
+
+.form-wrapper {
+  max-width: 520px;
+}
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+::v-deep input::placeholder {
+  color: #d9dede !important;
+}
+.font-color-gray {
+  color: #6d7570;
+}
+</style>

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -147,7 +147,7 @@
               >新規登録</v-btn
             >
             <v-btn
-              class="error pa-0 ma-0 text-h6 d-block d-sm-none"
+              class="warning pa-0 ma-0 text-h6 d-block d-sm-none"
               block
               :disabled="!form.valid"
               max-width="520"

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -8,7 +8,9 @@
   >
     <div class="px-4 pt-4 d-none d-sm-block">
       <p class="mb-0 text-right">
-        <NuxtLink to="#" class="text-overline text-decoration-none link-color"
+        <NuxtLink
+          to="/specialists/login"
+          class="text-overline text-decoration-none link-color"
           >ケアマネージャーの方はこちら</NuxtLink
         >
       </p>
@@ -17,7 +19,9 @@
     <div class="px-4 pt-4 d-flex justify-space-between d-sm-none">
       <h6 class="display-1 text-center text-h6 font-weight-black">ログイン</h6>
       <p class="mb-0 text-right">
-        <NuxtLink to="#" class="text-overline text-decoration-none link-color"
+        <NuxtLink
+          to="/specialists/login"
+          class="text-overline text-decoration-none link-color"
           >ケアマネージャーの方はこちら</NuxtLink
         >
       </p>
@@ -115,6 +119,7 @@ export default {
       loginInfo: {
         email: '',
         password: '',
+        redirecttUrl: '/top',
         valid: false,
       },
       formValidates: {

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -17,7 +17,7 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
       })
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログインしました'])
-      redirect('/top')
+      redirect(loginInfo.redirecttUrl)
       return response
     } catch (error) {
       return error


### PR DESCRIPTION
## 例

[link](https://dev.classmethod.jp/articles/pull-request-template/)

## チケットへのリンク

- https://example.com

## やったこと

- ケアマネージャーのログイン画面のレイアウトとページ遷移先の設定

## やらないこと

- ログイン権限の設定（現状：ユーザーもケアマネのログイン画面からログインできてしまう）

- ログイン後のヘッダーの設定

- エンドポイントの設定（現状：カスタマーと同じエンドポイントになっている）

## できるようになること（ユーザ目線）

- ケアマネージャーのログイン画面からログインできる

- ログイン後のページ遷移（仮でケアマネの新規登録画面に遷移するようになってます）

## できなくなること（ユーザ目線）

- なし

## 動作確認
ブランチ操作
```
git fetch
```
```
git checkout remotes/origin/feature/specialists_session
``` 
手順

```
1.yarn dev をしてサーバー立ち上げ
2.http://localhost:8000/specialists/loginにアクセス
3.ログインできるユーザーの値の入力（各自認証済みのユーザーのメアドとパスワード）
4.ケアマネの新規登録画面に遷移する
```
手順動画
https://www.loom.com/share/0f12b9f66d6e4b6dbe847c4742dc0a8b

## その他

- カスタマーのパスの設定や、リンクの文言などの修正もしてます
