### PR TITLE
build: スタッフ一覧画面作成

### DIFF
--- a/pages/specialists/office/_id/staffs/index.vue
+++ b/pages/specialists/office/_id/staffs/index.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
+    <h3>スタッフ情報</h3>
+    <v-row class="mt-4">
+      <v-col v-for="(staff, index) in staffs" :key="index" cols="12" md="6">
+        <v-card class="mx-auto mb-4">
+          <v-row>
+            <v-avatar size="80" color="grey lighten-3" class="ml-5 mt-3 mr-0">
+              <v-img
+                v-if="staff.image_url !== null"
+                :src="staff.image_url"
+              ></v-img>
+              <v-icon v-else size="60" color="white">mdi-account</v-icon>
+            </v-avatar>
+            <v-col cols="8" class="ml-0">
+              <h3 class="name-limit">
+                {{ staff.name }}
+              </h3>
+              <div
+                class="font-color-gray font-weight-black text-caption name-limit"
+              >
+                {{ staff.kana }}
+              </div>
+              <div class="mt-2 font-color-gray introduction-limit">
+                {{ staff.introduction }}
+              </div>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="4" class="pl-6 pr-0">
+              <v-btn block depressed outlined
+                ><div class="delete-button">削除</div></v-btn
+              >
+            </v-col>
+            <v-col cols="8" class="pr-6">
+              <v-btn block depressed color="warning">編集する</v-btn>
+            </v-col>
+          </v-row>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-btn
+      block
+      depressed
+      large
+      color="white"
+      class="mt-8 mb-10"
+      to="staffs/new"
+    >
+      <div class="delete-button">
+        <v-icon class="mb-1">mdi-plus</v-icon>
+        スタッフを追加する
+      </div>
+    </v-btn>
+  </v-col>
+</template>
+
+<script>
+export default {
+  layout: 'application_specialists',
+  async asyncData({ $axios, params }) {
+    let staffs = []
+    const id = `${params.id}`
+    await $axios
+      .$get(`specialists/offices/${id}/staffs`)
+      .then((res) => (staffs = res))
+    return { staffs }
+  },
+  data() {
+    return {}
+  },
+}
+</script>
+<style lang="scss" scoped>
+.name-limit {
+  /*  -webkit-boxを指定します */
+  display: -webkit-box;
+  /*  行数を指定します */
+  -webkit-line-clamp: 1;
+  /*  合わせてこの指定も必要です */
+  -webkit-box-orient: vertical;
+  /*  はみ出すものは隠します */
+  overflow: hidden;
+}
+
+.introduction-limit {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.font-color-gray {
+  color: #6d7570;
+}
+
+.delete-button {
+  color: #ff9800;
+}
+</style>

--- a/pages/specialists/office/_id/staffs/new.vue
+++ b/pages/specialists/office/_id/staffs/new.vue
@@ -2,7 +2,7 @@
   <div>
     <p class="mb-0 text-left link-width mx-auto">
       <NuxtLink
-        to=""
+        to="."
         class="text-overline text-decoration-none link-color sm-under-no"
         >＜ スタッフ情報一覧にもどる</NuxtLink
       >
@@ -70,13 +70,14 @@
             depressed
             :disabled="!valid"
             color="warning"
+            to="."
             @click="send"
           >
             登録する
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to=""
+              to="."
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >
@@ -127,10 +128,10 @@ export default {
         params.append('image', this.image)
       }
       try {
-        // `specialists/offices/${id}/staffs`
         await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
+        this.$router.push('.')
       } catch (error) {
         return error
       }
@@ -138,7 +139,6 @@ export default {
   },
 }
 </script>
-
 <style scoped>
 .link-color {
   color: #ee7b1a;


### PR DESCRIPTION
## やったこと

- スタッフ一覧画面作成
  - PC・SPレイアウト
  - スタッフ一覧取得
  - 画像がないスタッフは人型アイコン表示
  - 名前とふりがなは１行、紹介文は２行まで表示させ、それ以降は「...」と表記して隠す（スタイル崩れ防止のため）

- スタッフ一覧画面⇔スタッフ登録画面間の遷移
## やらないこと

- 編集・削除ボタンの実装（次スプリント対応）
- 事業所IDごとのスタッフの絞り込み（次スプリント以降対応）

## できるようになること（ユーザ目線）

- スタッフの一覧が見れる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- API側　fetch後、checkout

```
git fetch
```
```
git checkout feature/スタッフseed
```

- APIでfetchとcheckoutが終わったら、ダミーデータを作成する必要があります。まずは、APIのプルリクの動作確認の手順を行ってください
[https://github.com/koki-takishita/home-care-navi-api/pull/47](https://github.com/koki-takishita/home-care-navi-api/pull/47)

- fetch後、checkout
```
git fetch
```
```
git checkout origin feature/スタッフ一覧画面作成
```

- こちらのloomの動画をご覧ください。レイアウトの確認と、登録画面に遷移して実際にスタッフ登録を行ってください。
[loom スタッフ一覧画面](https://www.loom.com/share/4951c3a106d043f69a0f47fbc1894a95)

[PC-スタッフ一覧画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/626cc4a9-66a5-4daa-9885-b2284cf28a99)

[SP-スタッフ一覧画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/87805076-8dac-411b-a0ba-76e0ebd74de5)

- スタッフのサンプル画像です。ダウンロードしてアップロード時にお使いください。

![youngwoman_37](https://user-images.githubusercontent.com/34031637/170405379-876d203f-bb06-4abf-950b-d6d556eac5c7.png)

- スタッフ登録画面　入力用コピペ
```
スタッフ一覧画面のプルリクエストです。ああああああああああ
```
```
すたっふいちらんがめんの　ふりがなです　あああああああああ
```
```
スタッフ一覧画面の紹介文です。あああああああああああああああああああああああああああああああああああああああああああああああああああああああ
```

- 画像なしスタッフの場合
```
画像なしのスタッフです。
```
```
がぞうなしのすたっふです
```
```
画像なしスタッフの紹介文です。
```