### PR TITLE
Feature/問い合わせフォーム

### DIFF
--- a/pages/contacts/confirm.vue
+++ b/pages/contacts/confirm.vue
@@ -1,42 +1,59 @@
 <template>
-  <v-card width="750" class="mx-auto my-6">
-    <v-card-title>
-      <h4 class="display-1">入力内容をご確認ください。</h4>
-    </v-card-title>
+  <v-card width="750" class="mx-auto my-2">
+    <div class="px-4 pt-4 d-sm-block">
+      <h4 class="display-1 text-h6 font-weight-black">
+        入力内容をご確認ください
+      </h4>
+    </div>
     <v-card-text>
       <v-form>
+        <p class="font-color-gray font-weight-black">お名前</p>
         <p>
-          お名前<br />
           {{ name }}
         </p>
 
+        <p class="font-color-gray font-weight-black">返信用メールアドレス</p>
         <p>
-          返信用メールアドレス<br />
           {{ email }}
         </p>
+
+        <p class="font-color-gray font-weight-black">利用者区分</p>
         <p>
-          利用者区分<br />
           {{ types }}
         </p>
 
+        <p class="font-color-gray font-weight-black">お問い合わせ内容</p>
         <p>
-          お問い合わせ内容<br />
           {{ content }}
         </p>
 
         <div class="text-center mt-12">
-          <p>この内容で送信してよろしいですか？</p>
+          <p class="font-color-gray font-weight-black">
+            この内容で送信してよろしいですか？
+          </p>
         </div>
         <v-card-actions>
-          <v-btn to="/contacts/sucsess" class="info" block large>
+          <v-btn
+            to="/contacts/sucsess"
+            block
+            large
+            class="error text-h6 block"
+            max-width="520"
+            min-width="343"
+            height="60"
+          >
             送信する
           </v-btn>
         </v-card-actions>
-        <v-card-actions>
-          <NuxtLink class="text-decoration-none text-senter" to="/contacts/new">
+        <div class="mx-auto mt-4 text-center top-link mb-4">
+          <a
+            href="/contacts/new"
+            style="color: #f06364"
+            class="text-decoration-none"
+          >
             もどる
-          </NuxtLink>
-        </v-card-actions>
+          </a>
+        </div>
       </v-form>
     </v-card-text>
   </v-card>

--- a/pages/contacts/confirm.vue
+++ b/pages/contacts/confirm.vue
@@ -5,13 +5,24 @@
     </v-card-title>
     <v-card-text>
       <v-form>
-        <p>お名前</p>
+        <p>
+          お名前<br />
+          {{ name }}
+        </p>
 
-        <p>返信用メールアドレス</p>
+        <p>
+          返信用メールアドレス<br />
+          {{ email }}
+        </p>
+        <p>
+          利用者区分<br />
+          {{ types }}
+        </p>
 
-        <p>利用者区分</p>
-
-        <p>お問い合わせ内容</p>
+        <p>
+          お問い合わせ内容<br />
+          {{ content }}
+        </p>
 
         <div class="text-center mt-12">
           <p>この内容で送信してよろしいですか？</p>
@@ -22,7 +33,9 @@
           </v-btn>
         </v-card-actions>
         <v-card-actions>
-          <v-btn to="/contacts/new" class="info" block large> 戻る </v-btn>
+          <NuxtLink class="text-decoration-none text-senter" to="/contacts/new">
+            もどる
+          </NuxtLink>
         </v-card-actions>
       </v-form>
     </v-card-text>
@@ -32,23 +45,24 @@
 <script>
 export default {
   layout: 'application',
+  data() {
+    return {
+      name: '',
+      email: '',
+      types: '',
+      content: '',
+    }
+  },
   methods: {
-    contact() {
-      this.$router.push('/contacts/sucsses')
+    setParameter() {
+      this.name = this.$route.query.name
+      this.email = this.$route.query.email
+      this.types = this.$route.query.types
+      this.content = this.$route.query.content
     },
   },
+  mounted() {
+    this.setParameter()
+  },
 }
-/*      methods: {
-    async submit() {
-      /* this.response = await this.$http.$get('http://localhost:3000/api/users') */
-
-/*      this.response = await this.$http.$post(
-        'http://localhost:3000/api/contacts',
-        {
-          user: {
-            name: this.name,
-            email: this.email,
-          },
-        }
-        */
 </script>

--- a/pages/contacts/new.vue
+++ b/pages/contacts/new.vue
@@ -1,83 +1,79 @@
 <template>
   <v-card width="750" class="mx-auto mb-2">
     <div class="px-4 pt-4 d-sm-block">
-      <h4 class="display-1 text-center text-h6 font-weight-black">
-        お問い合わせ
-      </h4>
+      <h4 class="display-1 text-h6 font-weight-black">お問い合わせ</h4>
     </div>
     <v-card-text>
-      <div>
-        <v-form v-model="form.valid">
-          <div>
-            <label class="font-color-gray font-weight-black text-caption"
-              >お名前
-              <v-text-field
-                id="name"
-                v-model="form.name"
-                class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
-                placeholder="田中 太郎"
-                outlined
-                dense
-                height="44"
-                :rules="[formValidates.required]"
-            /></label>
-          </div>
-
-          <div class="mt-n-2">
-            <label class="font-color-gray font-weight-black text-caption"
-              >返信用メールアドレス
-              <v-text-field
-                v-model="form.email"
-                class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
-                outlined
-                dense
-                placeholder="homecarenavi@mail.com"
-                type="email"
-                height="44"
-                :rules="[formValidates.required, formValidates.email]"
-            /></label>
-          </div>
-
-          <label class="font-color-gray font-weight-black text-caption">
-            利用者区分
-            <v-row>
-              <v-col>
-                <v-select
-                  v-model="form.types"
-                  :items="items"
-                  outlined
-                  dense
-                  placeholder="ユーザー"
-                  :rules="[formValidates.required]"
-                ></v-select>
-              </v-col>
-            </v-row>
-          </label>
-          <label class="font-color-gray text-caption"
-            >お問い合わせ内容
-            <v-textarea
-              v-model="form.content"
+      <v-form v-model="form.valid">
+        <div>
+          <label class="font-color-gray font-weight-black text-caption"
+            >お名前
+            <v-text-field
+              id="name"
+              v-model="form.name"
+              class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
+              placeholder="田中 太郎"
               outlined
-              required="required"
-              placeholder="入力してください"
+              dense
+              height="44"
               :rules="[formValidates.required]"
-            />
-          </label>
+          /></label>
+        </div>
 
-          <v-card-actions class="pa-0">
-            <v-btn
-              class="error text-h6 block"
-              block
-              :disabled="!form.valid"
-              max-width="520"
-              min-width="343"
-              height="60"
-              @click="sendConfirmpage"
-              >この内容で問い合わせる</v-btn
-            >
-          </v-card-actions>
-        </v-form>
-      </div>
+        <div class="mt-n-2">
+          <label class="font-color-gray font-weight-black text-caption"
+            >返信用メールアドレス
+            <v-text-field
+              v-model="form.email"
+              class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
+              outlined
+              dense
+              placeholder="homecarenavi@mail.com"
+              type="email"
+              height="44"
+              :rules="[formValidates.required, formValidates.email]"
+          /></label>
+        </div>
+
+        <label class="font-color-gray font-weight-black text-caption">
+          利用者区分
+          <v-row>
+            <v-col>
+              <v-select
+                v-model="form.types"
+                :items="items"
+                outlined
+                dense
+                placeholder="ユーザー"
+                :rules="[formValidates.required]"
+              ></v-select>
+            </v-col>
+          </v-row>
+        </label>
+        <label class="font-color-gray text-caption"
+          >お問い合わせ内容
+          <v-textarea
+            v-model="form.content"
+            outlined
+            required="required"
+            placeholder="入力してください"
+            :rules="[formValidates.required]"
+          />
+        </label>
+
+        <v-card-actions class="pa-0">
+          <v-btn
+            class="error text-h6 block"
+            block
+            :disabled="!form.valid"
+            max-width="520"
+            min-width="343"
+            height="60"
+            @click="sendConfirmpage"
+            >この内容で問い合わせる</v-btn
+          >
+        </v-card-actions>
+      </v-form>
     </v-card-text>
   </v-card>
 </template>

--- a/pages/contacts/new.vue
+++ b/pages/contacts/new.vue
@@ -66,14 +66,13 @@
 
           <v-card-actions class="pa-0">
             <v-btn
-              to="/contacts/confirm"
               class="error text-h6 block"
               block
               :disabled="!form.valid"
               max-width="520"
               min-width="343"
               height="60"
-              @click="contact()"
+              @click="sendConfirmpage"
               >この内容で問い合わせる</v-btn
             >
           </v-card-actions>
@@ -102,20 +101,27 @@ export default {
           const format = /^[a-zA-Z0-9]+$/g
           return format.test(value) || '入力できるのは半角英数字のみです'
         },
-
         email: (value) => {
           const format =
             // eslint-disable-next-line no-control-regex
             /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
-        methods: {
-          contact() {
-            this.$router.push('/contacts/comfirm')
-          },
-        },
       },
     }
+  },
+  methods: {
+    sendConfirmpage() {
+      this.$router.push({
+        path: '/contacts/confirm',
+        query: {
+          name: this.form.name,
+          email: this.form.email,
+          types: this.form.types,
+          content: this.form.content,
+        },
+      })
+    },
   },
 }
 </script>

--- a/pages/contacts/sucsess.vue
+++ b/pages/contacts/sucsess.vue
@@ -1,12 +1,21 @@
 <template>
   <v-card outlined width="750" class="mx-auto mt-10">
     <v-card-text>
-      <h1 class="text-center mt-8 title-text">お問い合わせを送りました。</h1>
+      <div>
+        <h1 class="text-center mt-8 title-text d-none d-sm-block">
+          お問い合わせ完了
+        </h1>
+      </div>
+      <div>
+        <h1 class="mt-8 title-text d-sm-none">お問い合わせ完了</h1>
+      </div>
       <div class="text-center mt-12">
-        <p>サイト運営からのご返信をお待ちください。</p>
+        <p>
+          お問い合わせを送りました。<br />サイト運営からのご返信をお待ちください。
+        </p>
       </div>
       <div class="mx-auto mt-4 text-center top-link mb-16">
-        <a href="../top" style="color: #f06364">
+        <a href="../top" style="color: #f06364" class="text-decoration-none">
           <p>ホームケアナビトップに戻る</p>
         </a>
       </div>


### PR DESCRIPTION
## やったこと

- 入力項目のデータが確認画面で表示される
- レスポンシブ対応（確認画面・完了画面）

## やらないこと

- 確認画面：戻るボタンを押すと入力した項目をそのまま残して入力画面を表示する機能

## できるようになること（ユーザ目線）

- 確認画面で入力した文章などを確認できる

## できなくなること（ユーザ目線）
（無し）

## 動作確認
①問い合わせフォームで入力
http://localhost:8000/contacts/new
```
（コピペ用）入力用データ
佐渡　太郎
sado@gmail.com
問い合わせです。
```
https://gyazo.com/01f2d4840c1ccf91602af34a5a0c3ed7

②確認画面で入力したデータを確認

http://localhost:8000/contacts/confirm?name=佐渡%E3%80%80太郎&email=sado%40gmail.com&types=ユーザー&content=問い合わせです。
（URLには入力データが反映されてます）

https://gyazo.com/773ddab42611ff8cdc85420929bd3c7c

③確認画面・完了画面の レスポンシブ対応かを確認（XDのWeb予約の画面とで比較）
＜PC版＞
確認画面：
https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/4e5e4e48-7947-4389-b9dd-dc6c857d5b22/

完了画面：
https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/0df9ee79-2664-48ce-9064-82488f518a1c/

＜SP版＞
確認画面：
https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/f49098cd-b29b-4e27-8fa6-9e080db66240/

完了画面：
https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/e0499c4a-6701-4b7c-b568-7d9ebba60be7/

## その他

- レビュワーへの参考情報
