### PR TITLE
Feature/ログアウト後の遷移先設定

### DIFF
--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -53,7 +53,7 @@
                         :height="36"
                         color="error"
                         depressed
-                        @click.prevent="$logout()"
+                        @click.prevent="$logout(logoutInfo)"
                         >ログアウト</v-btn
                       >
                     </div>
@@ -142,7 +142,7 @@
                   color="error"
                   class="mr-2"
                   depressed
-                  @click.prevent="$logout()"
+                  @click.prevent="$logout(logoutInfo)"
                   >ログアウト</v-btn
                 >
               </div>
@@ -339,6 +339,10 @@ export default {
   layout: 'top',
   data() {
     return {
+      logoutInfo: {
+        redirecttUrl: '/top',
+        valid: false,
+      },
       justify: [],
       color_w: '#FFFFFF',
       color_g: '#6D7570',

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -27,7 +27,52 @@
             </v-col>
             <v-col md="8" class="ml-auto">
               <div class="d-flex justify-end">
-                <div class="red--text line-style">
+                <div v-if="$auth.loggedIn">
+                  <div class="mr-8 d-flex align-center">
+                    <NuxtLink
+                      to="#"
+                      class="header-style text-overline mr-5 text-decoration-none"
+                      >事業所情報編集</NuxtLink
+                    >
+                    <NuxtLink
+                      to="#"
+                      class="header-style text-overline mr-5 text-decoration-none"
+                      >スタッフ情報</NuxtLink
+                    >
+                    <NuxtLink
+                      to="#"
+                      class="header-style text-overline mr-5 text-decoration-none"
+                      >お礼一覧</NuxtLink
+                    >
+                    <NuxtLink
+                      to="#"
+                      class="header-style text-overline text-decoration-none mr-5"
+                      >予約状況確認</NuxtLink
+                    >
+                    <NuxtLink
+                      to="#"
+                      class="header-style text-overline text-decoration-none mr-5"
+                      >利用者情報管理</NuxtLink
+                    >
+                    <NuxtLink
+                      to="#"
+                      class="header-style text-overline text-decoration-none mr-5"
+                      >登録情報</NuxtLink
+                    >
+                    <div class="red--text line-style">
+                      <v-btn
+                        :width="120"
+                        :height="36"
+                        color="warning"
+                        depressed
+                        @click.prevent="$logout(logoutInfo)"
+                        >ログアウト</v-btn
+                      >
+                    </div>
+                  </div>
+                </div>
+
+                <div v-else class="red--text line-style">
                   <v-btn
                     href="/specialists/login"
                     :width="120"
@@ -37,7 +82,7 @@
                     >ログイン</v-btn
                   >
                   <v-btn
-                    href="new"
+                    href="/specialists/users/new"
                     :width="120"
                     :height="36"
                     color="warning"
@@ -112,7 +157,22 @@
                 />
               </v-list-item-title>
               <div class="header-style mt-3 text-caption ma-0">ゲストさん</div>
-              <div class="d-flex justify-center ma-0 mt-6">
+              <div
+                v-if="$auth.loggedIn"
+                class="d-flex justify-center ma-0 mt-6"
+              >
+                <v-btn
+                  href="/users/login"
+                  :width="120"
+                  :height="36"
+                  color="warning"
+                  class="mr-2"
+                  depressed
+                  @click.prevent="$logout(logoutInfo)"
+                  >ログアウト</v-btn
+                >
+              </div>
+              <div v-else class="d-flex justify-center ma-0 mt-6">
                 <v-btn
                   href="/specialists/login"
                   :width="120"
@@ -141,6 +201,88 @@
             </v-list-item-content>
           </v-list-item>
         </v-card>
+        <v-list v-if="$auth.loggedIn" nav dense class="pa-0">
+          <v-list-item-group v-model="group">
+            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+              <v-list-item-title>
+                <NuxtLink
+                  to="#"
+                  class="text-decoration-none text-body-2 navi-style"
+                  >事業所情報編集</NuxtLink
+                >
+              </v-list-item-title>
+              <v-list-item-icon class="ma-0 mt-2">
+                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+            <v-divider color="#D9DEDE"></v-divider>
+            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+              <v-list-item-title>
+                <NuxtLink
+                  to="#"
+                  class="text-decoration-none text-body-2 navi-style"
+                  >スタッフ情報</NuxtLink
+                >
+              </v-list-item-title>
+              <v-list-item-icon class="ma-0 mt-2">
+                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+            <v-divider color="#D9DEDE"></v-divider>
+            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+              <v-list-item-title>
+                <NuxtLink
+                  to="#"
+                  class="text-decoration-none text-body-2 navi-style"
+                  >お礼一覧</NuxtLink
+                >
+              </v-list-item-title>
+              <v-list-item-icon class="ma-0 mt-2">
+                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+            <v-divider color="#D9DEDE"></v-divider>
+            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+              <v-list-item-title>
+                <NuxtLink
+                  to="#"
+                  class="text-decoration-none text-body-2 navi-style"
+                  >予約状況確認</NuxtLink
+                >
+              </v-list-item-title>
+              <v-list-item-icon class="ma-0 mt-2">
+                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+            <v-divider color="#D9DEDE"></v-divider>
+            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+              <v-list-item-title>
+                <NuxtLink
+                  to="#"
+                  class="text-decoration-none text-body-2 navi-style"
+                  >利用者情報管理</NuxtLink
+                >
+              </v-list-item-title>
+              <v-list-item-icon class="ma-0 mt-2">
+                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+            <v-divider color="#D9DEDE"></v-divider>
+            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+              <v-list-item-title>
+                <NuxtLink
+                  to="#"
+                  class="text-decoration-none text-body-2 navi-style"
+                  >登録情報</NuxtLink
+                >
+              </v-list-item-title>
+              <v-list-item-icon class="ma-0 mt-2">
+                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+            <v-divider color="#D9DEDE"></v-divider>
+          </v-list-item-group>
+        </v-list>
       </div>
     </v-navigation-drawer>
 
@@ -235,6 +377,10 @@ export default {
   layout: 'top',
   data() {
     return {
+      logoutInfo: {
+        redirecttUrl: '/specialists/login',
+        valid: false,
+      },
       justify: [],
       color_w: '#FFFFFF',
       color_y: '#F09C3C',
@@ -245,9 +391,10 @@ export default {
       tile: false,
     }
   },
+
   methods: {
     topPage() {
-      window.location.href = 'http://localhost:8000/top'
+      window.location.href = 'http://localhost:8000/specialists/login'
     },
   },
 }

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -1,16 +1,16 @@
 export default function ({ $auth, redirect, store }, inject) {
-  inject('logout', () => {
-    logout()
+  inject('logout', (logoutInfo) => {
+    logout(logoutInfo)
+    console.log(logoutInfo)
   })
-
-  async function logout() {
+  async function logout(logoutInfo) {
     try {
-      const response = await $auth.logout()
+      const response = await $auth.logout(logoutInfo)
       authDataDeleteToLocalStorage()
       // TODO 成功時にstoreにtype入れ込む
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログアウトしました'])
-      redirect('/top')
+      redirect(logoutInfo.redirecttUrl)
       return response
     } catch (error) {
       // TODO 失敗時にstoreにtype入れ込む


### PR DESCRIPTION
## やったこと

- ログアウト後の遷移先設定
- 仮のログイン後のヘッダー作成（修正箇所まだありますので次スプリントでが対応します）

## やらないこと

- ログイン後のヘッダーのレイアウト（中途半端な幅になるとヘッダーのメニューが崩れます）
- ログアウト処理正常に動作していません
## できるようになること（ユーザ目線）

- ケアマネがログアウトするとログイン画面に遷移する
- ユーザーがログアウトするとユーザーのトップに遷移する
## できなくなること（ユーザ目線）

なし

## 動作確認

ブランチ操作
```
git fetch
```
```
git checkout remotes/origin/feature/specialists_session
``` 
手順

**ケアマネ**
```
1.yarn dev をしてサーバー立ち上げ
2.http://localhost:8000/specialists/loginにアクセス
3.ログインできるユーザーの値の入力（各自認証済みのユーザーのメアドとパスワード）
4.ケアマネの新規登録画面に遷移する
5.ログアウトボタンを押すとケアマネログイン画面に遷移する
```
確認動画
https://www.loom.com/share/9bcae04618704fc4b9b72e002dbdbcab


**カスタマー**
```
1.http://localhost:8000/users/loginにアクセス
2.ログインできるユーザーの値の入力（各自認証済みのユーザーのメアドとパスワード）
3.topに遷移する
4.カスタマー用の任意のページに行ってもらいログアウト
5.topに戻る

```
確認動画
https://www.loom.com/share/945b5011113e4273934387c567a8708e

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
