### PR TITLE
トップ画面一部レスポンシブ対応 SubComponent AreaCard

### DIFF
--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -1,27 +1,67 @@
 <template>
-  <div class="w-390">
-    <v-card min-height="324" max-width="375" class="pa-4" outlined>
-      <v-btn block color="error" min-height="48" outlined>
-        <v-icon small>mdi-map-marker</v-icon>
-        <span class="font-weight-black ml-2">現在地から探す</span>
-      </v-btn>
-      <div class="mt-3 d-flex justify-space-between flex-wrap w-343 h-232">
-        <v-card
-          v-for="(area, i) in areas"
-          :key="i"
-          hover
-          outlined
-          max-height="72"
-          min-width="109"
-          class="d-flex align-center"
-          @click="fetchAreas(area)"
-        >
-          <v-card-text class="text-center font-weight-black">
-            {{ area }}
-          </v-card-text>
+  <div>
+    <div class="d-none d-md-block">
+      <div class="w-390">
+        <v-card min-height="324" max-width="375" class="pa-4" outlined>
+          <v-btn block color="error" min-height="48" outlined>
+            <v-icon small>mdi-map-marker</v-icon>
+            <span class="font-weight-black ml-2">現在地から探す</span>
+          </v-btn>
+          <div class="mt-3 d-flex justify-space-between flex-wrap w-343 h-232">
+            <v-card
+              v-for="(area, i) in areas"
+              :key="i"
+              hover
+              outlined
+              max-height="72"
+              min-width="109"
+              class="d-flex align-center"
+              @click="fetchAreas(area)"
+            >
+              <v-card-text class="text-center font-weight-black">
+                {{ area }}
+              </v-card-text>
+            </v-card>
+          </div>
         </v-card>
       </div>
-    </v-card>
+    </div>
+    <div class="d-block d-md-none mt-4">
+      <v-card min-height="377" max-width="960" class="pa-4" outlined>
+        <div class="mt-3">
+          <v-text-field
+            placeholder="事業所名、市町村など"
+            append-icon="mdi-magnify"
+            outlined
+            rounded
+            hide-details
+          ></v-text-field>
+        </div>
+        <v-divider class="pa-0 mt-5 mb-5"></v-divider>
+        <v-btn block color="error" min-height="48" outlined>
+          <v-icon small>mdi-map-marker</v-icon>
+          <span class="font-weight-black ml-2">現在地から探す</span>
+        </v-btn>
+        <div
+          class="mt-3 d-flex justify-space-between flex-wrap w-343 h-232 mx-auto"
+        >
+          <v-card
+            v-for="(area, i) in areas"
+            :key="i"
+            hover
+            outlined
+            max-height="72"
+            min-width="109"
+            class="d-flex align-center"
+            @click="fetchAreas(area)"
+          >
+            <v-card-text class="text-center font-weight-black">
+              {{ area }}
+            </v-card-text>
+          </v-card>
+        </div>
+      </v-card>
+    </div>
   </div>
 </template>
 <script>
@@ -53,6 +93,7 @@ export default {
       this.setPrefectures(chooseArea)
       this.clearCities()
       this.clearCurrentPrefecture()
+      // if(this.vuetify.breakpoint.mobile){ this.router.push('') }
     },
     fetchAreaToTokyo() {
       this.setPrefectures('関東')

--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="test()">
     <div class="d-none d-md-block">
       <div class="w-390">
         <v-card min-height="324" max-width="375" class="pa-4" outlined>
@@ -65,7 +65,7 @@
   </div>
 </template>
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 export default {
   data() {
     return {
@@ -80,7 +80,22 @@ export default {
         '四国',
         '九州沖縄',
       ],
+      display: true,
     }
+  },
+  watch: {
+    /*
+    getCount_area() {
+      if( 2 <= this.getCount_area && this.$vuetify.breakpoint.smAndDown ) { this.display = false }
+      //else if(this.getCount_area <= 1 || this.$vuetify.breakpoint.mdAndUp) { this.display = true }
+    },
+    setDisplay() {
+      this.display = true
+    },
+*/
+  },
+  computed: {
+    ...mapGetters('areaData', ['getCount_area']),
   },
   methods: {
     ...mapActions('areaData', [
@@ -98,6 +113,18 @@ export default {
     fetchAreaToTokyo() {
       this.setPrefectures('関東')
       this.setCities('東京都')
+    },
+    test() {
+      // TODO ブレイキングポイントがモバイル用 + countが2以上
+      if (this.$vuetify.breakpoint.mdAndUp) {
+        return true
+      } else if (this.$vuetify.breakpoint.smAndDown && this.getCount_area > 1) {
+        console.log('はいった')
+        console.log(this.getCount_area)
+        console.log('this.$vuetify.breakpoint.smAndDown')
+        return false
+      }
+      return true
     },
   },
   mounted() {

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -1,49 +1,51 @@
 <template>
-  <v-card
-    min-height="324"
-    max-width="268"
-    outlined
-    class="pa-6 pt-5 pb-3 d-flex flex-column"
-  >
-    <v-list class="overflow-auto mb-auto" max-height="240">
-      <v-list-item v-for="(city, i) in cities" :key="i" dense class="">
-        <v-checkbox
-          v-model="chooseItems"
-          class="mt-n1"
-          multiple
-          dense
-          :value="cities[i].city"
-          hide-details
+  <div class="d-none d-md-block">
+    <v-card
+      min-height="324"
+      max-width="268"
+      outlined
+      class="pa-6 pt-5 pb-3 d-flex flex-column"
+    >
+      <v-list class="overflow-auto mb-auto" max-height="240">
+        <v-list-item v-for="(city, i) in cities" :key="i" dense>
+          <v-checkbox
+            v-model="chooseItems"
+            class="mt-n1"
+            multiple
+            dense
+            :value="cities[i].city"
+            hide-details
+          >
+          </v-checkbox>
+          <v-list-item-content class="text-button pa-0 ml-n2">
+            {{ city.city }}
+          </v-list-item-content>
+          <v-icon block>mdi-chevron-right</v-icon>
+        </v-list-item>
+      </v-list>
+      <div class="d-flex ml-n3">
+        <v-btn
+          min-width="80"
+          min-height="40"
+          class="mr-2"
+          outlined
+          depressed
+          @click="clearChoosenItems()"
         >
-        </v-checkbox>
-        <v-list-item-content class="text-button pa-0 ml-n2">
-          {{ city.city }}
-        </v-list-item-content>
-        <v-icon block>mdi-chevron-right</v-icon>
-      </v-list-item>
-    </v-list>
-    <div class="d-flex ml-n3">
-      <v-btn
-        min-width="80"
-        min-height="40"
-        class="mr-2"
-        outlined
-        depressed
-        @click="clearChoosenItems()"
-      >
-        <span class="color-red">クリア</span></v-btn
-      >
-      <v-btn
-        min-width="160"
-        min-height="40"
-        color="error"
-        depressed
-        class="font-weight-black"
-        @click="SearchForOfficesChosenByAddress"
-        >検索する</v-btn
-      >
-    </div>
-  </v-card>
+          <span class="color-red">クリア</span></v-btn
+        >
+        <v-btn
+          min-width="160"
+          min-height="40"
+          color="error"
+          depressed
+          class="font-weight-black"
+          @click="SearchForOfficesChosenByAddress"
+          >検索する</v-btn
+        >
+      </div>
+    </v-card>
+  </div>
 </template>
 <script>
 import { mapGetters } from 'vuex'

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -1,21 +1,23 @@
 <template>
-  <div class="w-283">
-    <v-card min-height="324" max-width="268" class="pa-6 pt-5" outlined>
-      <v-list dense class="overflow-auto" max-height="270">
-        <v-list-item
-          v-for="(prefecture, i) in prefectures"
-          :key="i"
-          @click="fetchCities(prefecture)"
-        >
-          <v-list-item-content class="text-button">
-            <span class="">{{ prefecture }}</span>
-          </v-list-item-content>
-          <v-list-item-icon>
-            <v-icon block>mdi-chevron-right</v-icon>
-          </v-list-item-icon>
-        </v-list-item>
-      </v-list>
-    </v-card>
+  <div class="d-none d-md-block">
+    <div class="w-283">
+      <v-card min-height="324" max-width="268" class="pa-6 pt-5" outlined>
+        <v-list dense class="overflow-auto" max-height="270">
+          <v-list-item
+            v-for="(prefecture, i) in prefectures"
+            :key="i"
+            @click="fetchCities(prefecture)"
+          >
+            <v-list-item-content class="text-button">
+              <span class="">{{ prefecture }}</span>
+            </v-list-item-content>
+            <v-list-item-icon>
+              <v-icon block>mdi-chevron-right</v-icon>
+            </v-list-item-icon>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </div>
   </div>
 </template>
 <script>

--- a/components/SubTitle.vue
+++ b/components/SubTitle.vue
@@ -18,8 +18,18 @@
         </div>
       </v-card>
     </div>
-    <div class="d-block d-md-none">
-      <p>test</p>
+    <div class="d-block d-md-none mt-3">
+      <v-card outlined tile class="d-flex justify-center" min-height="90">
+        <div class="my-auto set-color">
+          <p class="ma-0 text-h6 font-weight-black">
+            安心して介護をお願いしたいから。
+          </p>
+          <p class="ma-0 font-size-set">
+            ホームケアナビは、ケアマネージャーの検索ができるサービスです。
+          </p>
+        </div>
+        <v-icon large color="#F8BBD0"> mdi-cards-heart </v-icon>
+      </v-card>
     </div>
   </div>
 </template>
@@ -45,5 +55,9 @@ export default {}
 
 ::v-deep input::placeholder {
   color: #d9dede !important;
+}
+
+.font-size-set {
+  font-size: 0.5em;
 }
 </style>

--- a/components/SubTitle.vue
+++ b/components/SubTitle.vue
@@ -1,20 +1,27 @@
 <template>
-  <v-card outlined max-width="990" min-height="245" class="mx-auto">
-    <div class="text-center set-color font-weight-black mt-12">
-      <p class="fs-28 mb-2">安心して介護をお願いしたいから。</p>
-      <p class="text-caption mb-0">
-        ホームケアナビは、ケアマネージャーの検索ができるサービスです。
-      </p>
+  <div>
+    <div class="d-none d-md-block">
+      <v-card outlined max-width="990" min-height="245" class="mx-auto">
+        <div class="text-center set-color font-weight-black mt-12">
+          <p class="fs-28 mb-2">安心して介護をお願いしたいから。</p>
+          <p class="text-caption mb-0">
+            ホームケアナビは、ケアマネージャーの検索ができるサービスです。
+          </p>
+        </div>
+        <div class="mt-6 max-width-720 mx-auto">
+          <v-text-field
+            placeholder="事業所名、市町村など"
+            append-icon="mdi-magnify"
+            outlined
+            rounded
+          ></v-text-field>
+        </div>
+      </v-card>
     </div>
-    <div class="mt-6 max-width-720 mx-auto">
-      <v-text-field
-        placeholder="事業所名、市町村など"
-        append-icon="mdi-magnify"
-        outlined
-        rounded
-      ></v-text-field>
+    <div class="d-block d-md-none">
+      <p>test</p>
     </div>
-  </v-card>
+  </div>
 </template>
 <script>
 export default {}

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -85,7 +85,7 @@
     </div>
 
     <div class="d-md-none d-sm-flex">
-      <v-app-bar class="py-0" :color="color_w" max-height="52">
+      <v-app-bar class="py-0" :color="color_w" flat max-height="52">
         <v-row>
           <v-col sm="6">
             <v-toolbar-title class="fill-height d-flex">

--- a/pages/contacts/confirm.vue
+++ b/pages/contacts/confirm.vue
@@ -70,6 +70,9 @@ export default {
       content: '',
     }
   },
+  mounted() {
+    this.setParameter()
+  },
   methods: {
     setParameter() {
       this.name = this.$route.query.name
@@ -77,9 +80,6 @@ export default {
       this.types = this.$route.query.types
       this.content = this.$route.query.content
     },
-  },
-  mounted() {
-    this.setParameter()
   },
 }
 </script>

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -25,7 +25,8 @@ export default {
   },
   computed: {
     toggleClassByBreakpoints() {
-      if (this.$vuetify.breakpoint.width < this.toggleSize) {
+      // TODO mountedでやろうと思ったけど、mountedだとページの幅を変えた時が検知しない
+      if (this.$vuetify.breakpoint.smAndDown) {
         return this.mobileStyle
       } else {
         return this.pcStyle

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="w-990 mx-auto mt-n2 mb-2">
     <SubTitle />
-    <div class="mx-auto h-74 d-flex align-end">
+    <div class="mx-auto h-74 d-none d-md-flex align-end">
       <p class="color-dark-gray font-weight-black text-body-1">
         エリアから探す
       </p>
     </div>
-    <div class="d-flex justify-space-between">
+    <div :class="toggleClassByBreakpoints">
       <ChooseAreaCard />
       <ChoosePrefectureCard />
       <ChooseCityCard />
@@ -16,6 +16,22 @@
 <script>
 export default {
   layout: 'application',
+  data() {
+    return {
+      toggleSize: 960,
+      mobileStyle: '',
+      pcStyle: 'd-flex justify-space-between',
+    }
+  },
+  computed: {
+    toggleClassByBreakpoints() {
+      if (this.$vuetify.breakpoint.width < this.toggleSize) {
+        return this.mobileStyle
+      } else {
+        return this.pcStyle
+      }
+    },
+  },
 }
 </script>
 <style scoped>

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -42,12 +42,16 @@ export const state = () => ({
   prefectures: [],
   currentPrefecture: '',
   cities: [],
+  count_area: 0,
+  count_prefecture: 0,
 })
 
 export const getters = {
   getPrefectures: (state) => state.prefectures,
   getCurrentPrefecture: (state) => state.currentPrefecture,
   getCities: (state) => state.cities,
+  getCount_area: (state) => state.count_area,
+  getCount_prefecture: (state) => state.count_prefecture,
 }
 
 export const mutations = {
@@ -66,10 +70,29 @@ export const mutations = {
   clearCities(state) {
     state.cities = []
   },
+  increment_area(state) {
+    state.count_area++
+  },
+  decrement_area(state) {
+    state.count_area--
+  },
+  set_one_area(state) {
+    state.count_area = 1
+  },
+  increment_prefecture(state) {
+    state.count_prefecture++
+  },
+  decrement_prefecture(state) {
+    state.count_prefecture--
+  },
+  set_one_prefecture(state) {
+    state.count_prefecture = 1
+  },
 }
 
 export const actions = {
   setPrefectures({ commit }, chooseArea) {
+    commit('increment_area')
     if (chooseArea === '北海道') {
       commit('setPrefectures', areas.hokaido)
     } else if (chooseArea === '東北') {
@@ -103,6 +126,7 @@ export const actions = {
         requestMethods.cities + encodeString
       )
       const fetchCities = res.response.location
+      commit('increment_prefecture')
       commit('setCities', fetchCities)
       commit('setCurrentPrefecture', choosePrefecture)
     } catch (error) {
@@ -111,5 +135,23 @@ export const actions = {
   },
   clearCities({ commit }) {
     commit('clearCities')
+  },
+  increment_area({ commit }) {
+    commit('increment_area')
+  },
+  decrement_area({ commit }) {
+    commit('decrement_area')
+  },
+  increment_prefecture({ commit }) {
+    commit('increment_prefecture')
+  },
+  decrement_prefecture({ commit }) {
+    commit('decrement_prefecture')
+  },
+  set_one_area({ commit }) {
+    commit('set_one_area')
+  },
+  set_one_prefecture({ commit }) {
+    commit('set_one_prefecture')
   },
 }


### PR DESCRIPTION
## やったこと

1. TOP画面、サブタイトル・エリアカードスマホ対応

## やらないこと

1. 県・市町村カードスマホ対応
- 現在エリアカードスマホサイズ時に、エリアをクリックすると何も表示されなくなる挙動になっている(正常)
- 次のプルリクで、クリックした時に県・市町村のカードを表示する実装にする予定
2. 画面切り替え時に一瞬スタイルが崩れる(調査中)
試したけどだめだったやつ
- v-clock
- mounted

## できるようになること（ユーザ目線）

1. TOP画面の一部だが、スマホサイズに対応した

## できなくなること（ユーザ目線）

スマホサイズでは、県カードまでたどり着けない
[![Image from Gyazo](https://i.gyazo.com/4a984dc3ea17e270a99f4d5dbcad7100.gif)](https://gyazo.com/4a984dc3ea17e270a99f4d5dbcad7100)

## 動作確認
frontのみ
```ruby
git fetch && git ch origin/feature/build-top-page-responsive
```
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/specs/)
1. 幅によって、サブコンポーネントとエリアカードがスマホのレイアウトになっていることを確認
[![Image from Gyazo](https://i.gyazo.com/f5a4af9d7cf993bffbbdc3d8ac8a5819.gif)](https://gyazo.com/f5a4af9d7cf993bffbbdc3d8ac8a5819)

## その他
アイコンは、こちらで用意したもの使ってます。わけは下記のとおりです。
[![Image from Gyazo](https://i.gyazo.com/a915316aaeadcd6f6df47e2aace5aa84.png)](https://gyazo.com/a915316aaeadcd6f6df47e2aace5aa84)