### PR TITLE
スタッフ編集・削除機能実装

### DIFF
--- a/pages/contacts/confirm.vue
+++ b/pages/contacts/confirm.vue
@@ -70,6 +70,9 @@ export default {
       content: '',
     }
   },
+  mounted() {
+    this.setParameter()
+  },
   methods: {
     setParameter() {
       this.name = this.$route.query.name
@@ -77,9 +80,6 @@ export default {
       this.types = this.$route.query.types
       this.content = this.$route.query.content
     },
-  },
-  mounted() {
-    this.setParameter()
   },
 }
 </script>

--- a/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
@@ -12,7 +12,11 @@
       <v-form v-model="valid">
         <v-row>
           <v-avatar size="100" color="grey lighten-3" class="ml-6 my-4">
-            <v-icon size="70" color="white">mdi-account</v-icon>
+            <v-img
+              v-if="staff.image_url !== null"
+              :src="staff.image_url"
+            ></v-img>
+            <v-icon v-else size="60" color="white">mdi-account</v-icon>
           </v-avatar>
           <v-file-input
             v-model="image"
@@ -29,7 +33,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >スタッフ名
             <v-text-field
-              v-model="name"
+              v-model="staff.name"
               :rules="[formValidates.required, formValidates.nameCountCheck]"
               class="mt-2 font-weight-regular"
               placeholder="田中 太郎"
@@ -40,7 +44,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >スタッフ名(ふりがな)
             <v-text-field
-              v-model="kana"
+              v-model="staff.kana"
               :rules="[
                 formValidates.required,
                 formValidates.nameCountCheck,
@@ -55,7 +59,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >スタッフ紹介文
             <v-textarea
-              v-model="introduction"
+              v-model="staff.introduction"
               :rules="[formValidates.introductionCountCheck]"
               class="mt-2 font-weight-regular"
               height="80"
@@ -90,6 +94,15 @@
 <script>
 export default {
   layout: 'application_specialists',
+  async asyncData({ $axios, params }) {
+    let array = []
+    const officeId = `${params.office_id}`
+    const staffId = `${params.staff_id}`
+    await $axios
+      .$get(`specialists/offices/${officeId}/staffs/${staffId}`)
+      .then((res) => (array = res))
+    return { staff: array }
+  },
   data() {
     return {
       formValidates: {
@@ -109,11 +122,9 @@ export default {
       },
       office_id: this.$route.params.office_id,
       staff_id: this.$route.params.staff_id,
-      name: '',
-      kana: '',
-      introduction: '',
       image: null,
       valid: false,
+      staff: [],
     }
   },
   methods: {
@@ -121,10 +132,10 @@ export default {
       const officeId = this.office_id
       const staffId = this.staff_id
       const params = new FormData()
-      params.append('office_id', this.office_id)
-      params.append('name', this.name)
-      params.append('kana', this.kana)
-      params.append('introduction', this.introduction)
+      params.append('office_id', this.staff.office_id)
+      params.append('name', this.staff.name)
+      params.append('kana', this.staff.kana)
+      params.append('introduction', this.staff.introduction)
       if (this.image !== null) {
         params.append('image', this.image)
       }
@@ -136,6 +147,8 @@ export default {
             headers: { 'Content-Type': 'multipart/form-data' },
           }
         )
+        this.$store.commit('catchErrorMsg/setType', 'success')
+        this.$store.commit('catchErrorMsg/setMsg', ['変更しました'])
         this.$router.push('..')
       } catch (error) {
         return error

--- a/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
@@ -2,7 +2,7 @@
   <div>
     <p class="mb-0 text-left link-width mx-auto">
       <NuxtLink
-        to="."
+        to=".."
         class="text-overline text-decoration-none link-color sm-under-no"
         >＜ スタッフ情報一覧にもどる</NuxtLink
       >
@@ -70,14 +70,13 @@
             depressed
             :disabled="!valid"
             color="warning"
-            to="."
             @click="send"
           >
-            登録する
+            変更する
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to="."
+              to=".."
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >
@@ -108,7 +107,8 @@ export default {
         introductionCountCheck: (value) =>
           value.length <= 81 || '80文字以下で入力してください',
       },
-      office_id: this.$route.params.id,
+      office_id: this.$route.params.office_id,
+      staff_id: this.$route.params.staff_id,
       name: '',
       kana: '',
       introduction: '',
@@ -118,7 +118,8 @@ export default {
   },
   methods: {
     async send() {
-      const id = this.office_id
+      const officeId = this.office_id
+      const staffId = this.staff_id
       const params = new FormData()
       params.append('office_id', this.office_id)
       params.append('name', this.name)
@@ -128,10 +129,14 @@ export default {
         params.append('image', this.image)
       }
       try {
-        await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-        })
-        this.$router.push('.')
+        await this.$axios.$put(
+          `specialists/offices/${officeId}/staffs/${staffId}`,
+          params,
+          {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          }
+        )
+        this.$router.push('..')
       } catch (error) {
         return error
       }

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -51,7 +51,7 @@
       large
       color="white"
       class="mt-8 mb-10"
-      to="staffs/new"
+      @click="goStaffNewPage"
     >
       <div class="delete-button">
         <v-icon class="mb-1">mdi-plus</v-icon>
@@ -64,13 +64,24 @@
 <script>
 export default {
   layout: 'application_specialists',
-  async asyncData({ $axios, params }) {
-    let staffs = []
-    const id = `${params.id}`
-    await $axios
-      .$get(`specialists/offices/${id}/staffs`)
-      .then((res) => (staffs = res))
-    return { staffs }
+  data() {
+    return {
+      staffs: [],
+      officeId: this.$route.params.office_id,
+    }
+  },
+  async fetch() {
+    this.staffs = await fetch(
+      // home-care-navi-v2/api/specialists/offices/${this.officeId}/staffs
+      `http://localhost:3000/api/specialists/offices/${this.officeId}/staffs`
+    ).then((res) => res.json())
+  },
+  methods: {
+    goStaffNewPage() {
+      this.$store.commit('catchErrorMsg/setType', '')
+      this.$store.commit('catchErrorMsg/clearMsg')
+      this.$router.push('staffs/new')
+    },
   },
 }
 </script>

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -33,7 +33,13 @@
               >
             </v-col>
             <v-col cols="8" class="pr-6">
-              <v-btn block depressed color="warning">編集する</v-btn>
+              <v-btn
+                block
+                depressed
+                color="warning"
+                :to="`staffs/${staff.id}/edit`"
+                >編集する</v-btn
+              >
             </v-col>
           </v-row>
         </v-card>
@@ -65,9 +71,6 @@ export default {
       .$get(`specialists/offices/${id}/staffs`)
       .then((res) => (staffs = res))
     return { staffs }
-  },
-  data() {
-    return {}
   },
 }
 </script>

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -28,7 +28,7 @@
           </v-row>
           <v-row>
             <v-col cols="4" class="pl-6 pr-0">
-              <v-btn block depressed outlined
+              <v-btn block depressed outlined @click="deleteStaff(staff.id)"
                 ><div class="delete-button">削除</div></v-btn
               >
             </v-col>
@@ -81,6 +81,19 @@ export default {
       this.$store.commit('catchErrorMsg/setType', '')
       this.$store.commit('catchErrorMsg/clearMsg')
       this.$router.push('staffs/new')
+    },
+    async deleteStaff(id) {
+      const isDeleted = '本当に削除してもよろしいですか？'
+      if (window.confirm(isDeleted)) {
+        try {
+          await this.$axios.$delete(
+            `specialists/offices/${this.officeId}/staffs/${id}`
+          )
+          window.location.reload()
+        } catch (error) {
+          return error
+        }
+      }
     },
   },
 }

--- a/pages/specialists/office/_office_id/staffs/new.vue
+++ b/pages/specialists/office/_office_id/staffs/new.vue
@@ -1,0 +1,164 @@
+<template>
+  <div>
+    <p class="mb-0 text-left link-width mx-auto">
+      <NuxtLink
+        to="."
+        class="text-overline text-decoration-none link-color sm-under-no"
+        >＜ スタッフ情報一覧にもどる</NuxtLink
+      >
+    </p>
+    <v-card class="mx-auto mb-2 p-0" width="750">
+      <v-col cols="12"><h3>スタッフ登録</h3></v-col>
+      <v-form v-model="valid">
+        <v-row>
+          <v-avatar size="100" color="grey lighten-3" class="ml-6 my-4">
+            <v-icon size="70" color="white">mdi-account</v-icon>
+          </v-avatar>
+          <v-file-input
+            v-model="image"
+            truncate-length="20"
+            :rules="[formValidates.fileSizeCheck]"
+            accept="image/*"
+            prepend-icon="mdi-camera"
+            label="画像をアップロードする"
+            class="mt-15 ml-3 image-form"
+          >
+          </v-file-input>
+        </v-row>
+        <v-col cols="12">
+          <label class="font-color-gray font-weight-black text-caption"
+            >スタッフ名
+            <v-text-field
+              v-model="name"
+              :rules="[formValidates.required, formValidates.nameCountCheck]"
+              class="mt-2 font-weight-regular"
+              placeholder="田中 太郎"
+              outlined
+              dense
+              height="44"
+          /></label>
+          <label class="font-color-gray font-weight-black text-caption"
+            >スタッフ名(ふりがな)
+            <v-text-field
+              v-model="kana"
+              :rules="[
+                formValidates.required,
+                formValidates.nameCountCheck,
+                formValidates.kanaCheck,
+              ]"
+              class="mt-2 font-weight-regular"
+              placeholder="たなか たろう"
+              outlined
+              dense
+              height="44"
+          /></label>
+          <label class="font-color-gray font-weight-black text-caption"
+            >スタッフ紹介文
+            <v-textarea
+              v-model="introduction"
+              :rules="[formValidates.introductionCountCheck]"
+              class="mt-2 font-weight-regular"
+              height="80"
+              outlined
+              dense
+            >
+            </v-textarea
+          ></label>
+          <v-btn
+            x-large
+            block
+            depressed
+            :disabled="!valid"
+            color="warning"
+            @click="send"
+          >
+            登録する
+          </v-btn>
+          <p class="mb-0 text-center">
+            <NuxtLink
+              to="."
+              class="text-overline text-decoration-none link-color"
+              >もどる</NuxtLink
+            >
+          </p>
+        </v-col>
+      </v-form>
+    </v-card>
+  </div>
+</template>
+
+<script>
+export default {
+  layout: 'application_specialists',
+  data() {
+    return {
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        fileSizeCheck: (value) =>
+          !value ||
+          value.size <= 10000000 ||
+          '画像サイズは10MB以下でアップロードしてください',
+        nameCountCheck: (value) =>
+          value.length <= 31 || '30文字以下で入力してください',
+        kanaCheck: (value) => {
+          const format = /^[ぁ-んー　 ]*$/ // eslint-disable-line
+          return format.test(value) || 'ひらがなで入力してください'
+        },
+        introductionCountCheck: (value) =>
+          value.length <= 81 || '80文字以下で入力してください',
+      },
+      office_id: this.$route.params.office_id,
+      name: '',
+      kana: '',
+      introduction: '',
+      image: null,
+      valid: false,
+    }
+  },
+  methods: {
+    async send() {
+      const id = this.office_id
+      const params = new FormData()
+      params.append('office_id', this.office_id)
+      params.append('name', this.name)
+      params.append('kana', this.kana)
+      params.append('introduction', this.introduction)
+      if (this.image !== null) {
+        params.append('image', this.image)
+      }
+      try {
+        await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        })
+        this.$router.push('.')
+      } catch (error) {
+        return error
+      }
+    },
+  },
+}
+</script>
+<style scoped>
+.link-color {
+  color: #ee7b1a;
+}
+
+.font-color-gray {
+  color: #6d7570;
+}
+
+.link-width {
+  width: 750px;
+}
+
+@media screen and (max-width: 959px) {
+  /* sm以下で表示しない */
+  .sm-under-no {
+    display: none;
+  }
+}
+/* stylelint-disable */
+.image-form >>> .v-input__slot {
+  width: 200px;
+}
+</style>

--- a/pages/specialists/office/_office_id/staffs/new.vue
+++ b/pages/specialists/office/_office_id/staffs/new.vue
@@ -130,6 +130,8 @@ export default {
         await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
+        this.$store.commit('catchErrorMsg/setType', 'success')
+        this.$store.commit('catchErrorMsg/setMsg', ['登録しました'])
         this.$router.push('.')
       } catch (error) {
         return error

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -1,7 +1,7 @@
 export default function ({ $auth, redirect, store }, inject) {
   inject('logout', (logoutInfo) => {
     logout(logoutInfo)
-    console.log(logoutInfo)
+    // console.log(logoutInfo)
   })
   async function logout(logoutInfo) {
     try {


### PR DESCRIPTION
## やったこと

- このプルリクで何をしたのか？

1. スタッフ編集画面作成
2. 編集画面に遷移するときにスタッフの詳細データ表示
3. スタッフ登録・編集時にフラッシュメッセージ表示
4. スタッフ削除ボタン実装（モーダル表示）

## やらないこと

- なし

## できるようになること（ユーザ目線）

1. スタッフの編集・削除ができるようになる

## できなくなること（ユーザ目線）

- なし

## 動作確認

### API 側

- fetch and checkout
- **削除機能を追加しました**

```ruby
git fetch && git checkout origin/feature/staff-destroy
```
APIの動作確認を終わらせる

https://github.com/koki-takishita/home-care-navi-api/pull/53

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/staff-edit
```

### Loom 手順
- スタッフ一覧画面から、編集ボタンをクリックし、編集する。
http://localhost:8000/specialists/office/1/staffs
- 動画更新しました。編集画面でデータが表示されているのと、フラッシュメッセージの表示の確認をお願いします。
- 削除機能実装しました。編集と削除で動画を2つに分けています。
[スタッフ編集　手順動画](https://www.loom.com/share/a919b4d26c2f40a3bab42d33424315dd)
[スタッフ削除　手順動画](https://www.loom.com/share/97cf4cd874a84653a727c1edbb3dd3b8)
### その他
- スタッフ一覧画面でfetchを使っているのですが、fetchの場合`nuxt.config.js`で定義した`baseURL`が使えないので、エンドポイントをlocalhostから書いています。本番環境に上げるとき、エンドポイントの修正が必要です。
```nuxt.js
async fetch() {
    this.staffs = await fetch(
      // home-care-navi-v2/api/specialists/offices/${this.officeId}/staffs
      `http://localhost:3000/api/specialists/offices/${this.officeId}/staffs`
    ).then((res) => res.json())
  },
```