### PR TITLE
エリア・県・市カード

### DIFF
--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="test()">
+  <div v-if="displayControll()">
     <div class="d-none d-md-block">
       <div class="w-390">
         <v-card min-height="324" max-width="375" class="pa-4" outlined>
@@ -83,17 +83,6 @@ export default {
       display: true,
     }
   },
-  watch: {
-    /*
-    getCount_area() {
-      if( 2 <= this.getCount_area && this.$vuetify.breakpoint.smAndDown ) { this.display = false }
-      //else if(this.getCount_area <= 1 || this.$vuetify.breakpoint.mdAndUp) { this.display = true }
-    },
-    setDisplay() {
-      this.display = true
-    },
-*/
-  },
   computed: {
     ...mapGetters('areaData', ['getCount_area']),
   },
@@ -114,14 +103,11 @@ export default {
       this.setPrefectures('関東')
       this.setCities('東京都')
     },
-    test() {
+    displayControll() {
       // TODO ブレイキングポイントがモバイル用 + countが2以上
       if (this.$vuetify.breakpoint.mdAndUp) {
         return true
       } else if (this.$vuetify.breakpoint.smAndDown && this.getCount_area > 1) {
-        console.log('はいった')
-        console.log(this.getCount_area)
-        console.log('this.$vuetify.breakpoint.smAndDown')
         return false
       }
       return true

--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -84,7 +84,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('areaData', ['getCount_area']),
+    ...mapGetters('areaData', ['getCount_area', 'getCount_prefecture']),
   },
   methods: {
     ...mapActions('areaData', [
@@ -107,7 +107,10 @@ export default {
       // TODO ブレイキングポイントがモバイル用 + countが2以上
       if (this.$vuetify.breakpoint.mdAndUp) {
         return true
-      } else if (this.$vuetify.breakpoint.smAndDown && this.getCount_area > 1) {
+      } else if (
+        (this.$vuetify.breakpoint.smAndDown && this.getCount_area > 1) ||
+        this.getCount_prefecture > 1
+      ) {
         return false
       }
       return true

--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -84,7 +84,11 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('areaData', ['getCount_area', 'getCount_prefecture']),
+    ...mapGetters('areaData', [
+      'getCount_area',
+      'getCount_prefecture',
+      'getCount_city',
+    ]),
   },
   methods: {
     ...mapActions('areaData', [
@@ -92,8 +96,12 @@ export default {
       'setCities',
       'clearCities',
       'clearCurrentPrefecture',
+      'set_one_city',
+      'set_one_prefecture',
     ]),
     fetchAreas(chooseArea) {
+      this.set_one_city()
+      this.set_one_prefecture()
       this.setPrefectures(chooseArea)
       this.clearCities()
       this.clearCurrentPrefecture()
@@ -109,7 +117,8 @@ export default {
         return true
       } else if (
         (this.$vuetify.breakpoint.smAndDown && this.getCount_area > 1) ||
-        this.getCount_prefecture > 1
+        this.getCount_prefecture > 1 ||
+        this.getCount_city > 1
       ) {
         return false
       }

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -17,6 +17,7 @@
               :value="cities[i].city"
               hide-details
               color="red"
+              @click="countUp()"
             >
             </v-checkbox>
             <v-list-item-content class="text-button pa-0 ml-n2">
@@ -78,6 +79,7 @@
               :value="cities[i].city"
               hide-details
               color="red"
+              @click="countUp()"
             >
             </v-checkbox>
             <v-list-item-content class="text-button pa-0 ml-n2">
@@ -134,10 +136,16 @@ export default {
       'getCities',
       'getCurrentPrefecture',
       'getCount_prefecture',
+      'getCount_city',
     ]),
   },
   methods: {
-    ...mapActions('areaData', ['set_one_prefecture']),
+    ...mapActions('areaData', [
+      'set_one_prefecture',
+      'set_one_city',
+      'increment_city',
+      'increment_prefecture',
+    ]),
     async SearchForOfficesChosenByAddress() {
       if (this.chooseItems.length === 0) {
         alert('市町村を１つ以上選択してください。')
@@ -159,10 +167,7 @@ export default {
       this.chooseItems = []
     },
     displayControll() {
-      // vuexにcheckboxにチェックが入ったかを記録
-      if (
-        this.$vuetify.breakpoint.mdAndUp /* || this.chooseItems.length > 0 */
-      ) {
+      if (this.$vuetify.breakpoint.mdAndUp || this.getCount_city > 1) {
         return true
       } else if (
         (this.$vuetify.breakpoint.smAndDown &&
@@ -174,7 +179,16 @@ export default {
       return true
     },
     backPrefecture() {
+      this.chooseItems = []
+      this.set_one_city()
       this.set_one_prefecture()
+    },
+    countUp() {
+      if (this.chooseItems.length >= 1) {
+        this.increment_city()
+      } else if (this.chooseItems.length === 0) {
+        this.set_one_city()
+      }
     },
   },
 }

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -145,6 +145,7 @@ export default {
       'set_one_city',
       'increment_city',
       'increment_prefecture',
+      'increment_area',
     ]),
     async SearchForOfficesChosenByAddress() {
       if (this.chooseItems.length === 0) {
@@ -182,12 +183,15 @@ export default {
       this.chooseItems = []
       this.set_one_city()
       this.set_one_prefecture()
+      this.increment_area()
     },
     countUp() {
       if (this.chooseItems.length >= 1) {
         this.increment_city()
       } else if (this.chooseItems.length === 0) {
         this.set_one_city()
+        console.log('countup')
+        // this.increment_area()
       }
     },
   },

--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -1,54 +1,116 @@
 <template>
-  <div class="d-none d-md-block">
-    <v-card
-      min-height="324"
-      max-width="268"
-      outlined
-      class="pa-6 pt-5 pb-3 d-flex flex-column"
-    >
-      <v-list class="overflow-auto mb-auto" max-height="240">
-        <v-list-item v-for="(city, i) in cities" :key="i" dense>
-          <v-checkbox
-            v-model="chooseItems"
-            class="mt-n1"
-            multiple
-            dense
-            :value="cities[i].city"
-            hide-details
+  <div v-if="displayControll()">
+    <div class="d-none d-md-block">
+      <v-card
+        min-height="324"
+        max-width="268"
+        outlined
+        class="pa-6 pt-5 pb-3 d-flex flex-column"
+      >
+        <v-list class="overflow-auto mb-auto" max-height="240">
+          <v-list-item v-for="(city, i) in cities" :key="i" dense>
+            <v-checkbox
+              v-model="chooseItems"
+              class="mt-n1"
+              multiple
+              dense
+              :value="cities[i].city"
+              hide-details
+              color="red"
+            >
+            </v-checkbox>
+            <v-list-item-content class="text-button pa-0 ml-n2">
+              {{ city.city }}
+            </v-list-item-content>
+            <v-icon block>mdi-chevron-right</v-icon>
+          </v-list-item>
+        </v-list>
+        <div class="d-flex ml-n3">
+          <v-btn
+            min-width="80"
+            min-height="40"
+            class="mr-2"
+            outlined
+            depressed
+            @click="clearChoosenItems()"
           >
-          </v-checkbox>
-          <v-list-item-content class="text-button pa-0 ml-n2">
-            {{ city.city }}
-          </v-list-item-content>
-          <v-icon block>mdi-chevron-right</v-icon>
-        </v-list-item>
-      </v-list>
-      <div class="d-flex ml-n3">
-        <v-btn
-          min-width="80"
-          min-height="40"
-          class="mr-2"
-          outlined
-          depressed
-          @click="clearChoosenItems()"
-        >
-          <span class="color-red">クリア</span></v-btn
-        >
-        <v-btn
-          min-width="160"
-          min-height="40"
-          color="error"
-          depressed
-          class="font-weight-black"
-          @click="SearchForOfficesChosenByAddress"
-          >検索する</v-btn
-        >
-      </div>
-    </v-card>
+            <span class="color-red">クリア</span></v-btn
+          >
+          <v-btn
+            min-width="160"
+            min-height="40"
+            color="error"
+            depressed
+            class="font-weight-black"
+            @click="SearchForOfficesChosenByAddress"
+            >検索する</v-btn
+          >
+        </div>
+      </v-card>
+    </div>
+    <div class="d-block d-md-none pa-4">
+      <h3 class="mb-4">エリアを選択してください</h3>
+      <v-card
+        color="grey lighten-1"
+        outlined
+        class="d-flex pl-2"
+        min-height="40"
+        hover
+        @click="backPrefecture()"
+      >
+        <v-icon block>mdi-chevron-left</v-icon>
+        <p class="text-body-2 my-auto">{{ choosePrefecture }}</p>
+      </v-card>
+
+      <v-card
+        min-height="361"
+        outlined
+        class="pa-6 pt-5 pb-3 d-flex flex-column"
+      >
+        <v-list class="overflow-auto mb-auto pt-0" max-height="240">
+          <p>{{ choosePrefecture }}</p>
+          <v-list-item v-for="(city, i) in cities" :key="i" dense>
+            <v-checkbox
+              v-model="chooseItems"
+              class="mt-n1"
+              multiple
+              dense
+              :value="cities[i].city"
+              hide-details
+              color="red"
+            >
+            </v-checkbox>
+            <v-list-item-content class="text-button pa-0 ml-n2">
+              {{ city.city }}
+            </v-list-item-content>
+            <v-icon block>mdi-chevron-right</v-icon>
+          </v-list-item>
+        </v-list>
+        <div class="wrapper">
+          <v-btn
+            min-height="40"
+            class="mr-2"
+            outlined
+            depressed
+            @click="clearChoosenItems()"
+          >
+            <span class="color-red">クリア</span></v-btn
+          >
+          <v-btn
+            min-height="40"
+            color="error"
+            depressed
+            class="font-weight-black"
+            @click="SearchForOfficesChosenByAddress"
+            >検索する</v-btn
+          >
+        </div>
+      </v-card>
+    </div>
   </div>
 </template>
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 export default {
   data() {
     return {
@@ -68,9 +130,14 @@ export default {
     },
   },
   computed: {
-    ...mapGetters('areaData', ['getCities', 'getCurrentPrefecture']),
+    ...mapGetters('areaData', [
+      'getCities',
+      'getCurrentPrefecture',
+      'getCount_prefecture',
+    ]),
   },
   methods: {
+    ...mapActions('areaData', ['set_one_prefecture']),
     async SearchForOfficesChosenByAddress() {
       if (this.chooseItems.length === 0) {
         alert('市町村を１つ以上選択してください。')
@@ -91,11 +158,34 @@ export default {
     clearChoosenItems() {
       this.chooseItems = []
     },
+    displayControll() {
+      // vuexにcheckboxにチェックが入ったかを記録
+      if (
+        this.$vuetify.breakpoint.mdAndUp /* || this.chooseItems.length > 0 */
+      ) {
+        return true
+      } else if (
+        (this.$vuetify.breakpoint.smAndDown &&
+          this.getCount_prefecture === 1) ||
+        this.getCount_prefecture === 1
+      ) {
+        return false
+      }
+      return true
+    },
+    backPrefecture() {
+      this.set_one_prefecture()
+    },
   },
 }
 </script>
 <style>
 .color-red {
   color: red;
+}
+
+.wrapper {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
 }
 </style>

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -69,7 +69,7 @@ export default {
     ]),
   },
   methods: {
-    ...mapActions('areaData', ['setCities', 'decrement_area']),
+    ...mapActions('areaData', ['setCities', 'set_one_area']),
     fetchCities(choosePrefecture) {
       this.setCities(choosePrefecture)
     },
@@ -85,7 +85,7 @@ export default {
       return true
     },
     backArea() {
-      this.decrement_area()
+      this.set_one_area()
     },
   },
 }

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -23,13 +23,20 @@
     <div class="d-block d-md-none pa-4">
       <h3 class="mb-4">エリアを選択してください</h3>
       <div class="w-283">
-        <!--<v-btn @click="backArea()">戻る</v-btn>-->
-        <v-card color="blue" outlined class="pl-2" @click="backArea()">
-          <v-icon>mdi-chevron-left</v-icon>
-          <p class="mb-0"></p>
+        <v-card
+          color="grey lighten-1"
+          outlined
+          class="d-flex pl-2"
+          min-height="40"
+          hover
+          @click="backArea()"
+        >
+          <v-icon block>mdi-chevron-left</v-icon>
+          <p class="text-body-2 my-auto">{{ selectedArea }}地方</p>
         </v-card>
-        <v-card min-height="324" max-width="960" class="pa-6 pt-5" outlined>
-          <v-list dense class="overflow-auto">
+        <v-card max-width="960" class="pa-6 pt-5" outlined>
+          <v-list dense class="overflow-auto pt-0">
+            <p>{{ selectedArea }}</p>
             <v-list-item
               v-for="(prefecture, i) in prefectures"
               :key="i"
@@ -54,15 +61,20 @@ export default {
   data() {
     return {
       prefectures: [],
+      selectedArea: '',
     }
   },
   watch: {
     getPrefectures() {
       this.prefectures = this.getPrefectures
     },
+    getCurrentArea() {
+      this.selectedArea = this.getCurrentArea
+    },
   },
   computed: {
     ...mapGetters('areaData', [
+      'getCurrentArea',
       'getPrefectures',
       'getCount_prefecture',
       'getCount_area',

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -1,22 +1,50 @@
 <template>
-  <div class="d-none d-md-block">
-    <div class="w-283">
-      <v-card min-height="324" max-width="268" class="pa-6 pt-5" outlined>
-        <v-list dense class="overflow-auto" max-height="270">
-          <v-list-item
-            v-for="(prefecture, i) in prefectures"
-            :key="i"
-            @click="fetchCities(prefecture)"
-          >
-            <v-list-item-content class="text-button">
-              <span class="">{{ prefecture }}</span>
-            </v-list-item-content>
-            <v-list-item-icon>
-              <v-icon block>mdi-chevron-right</v-icon>
-            </v-list-item-icon>
-          </v-list-item>
-        </v-list>
-      </v-card>
+  <div v-if="displayControll()">
+    <div class="d-none d-md-block">
+      <div class="w-283">
+        <v-card min-height="324" max-width="268" class="pa-6 pt-5" outlined>
+          <v-list dense class="overflow-auto" max-height="270">
+            <v-list-item
+              v-for="(prefecture, i) in prefectures"
+              :key="i"
+              @click="fetchCities(prefecture)"
+            >
+              <v-list-item-content class="text-button">
+                <span class="">{{ prefecture }}</span>
+              </v-list-item-content>
+              <v-list-item-icon>
+                <v-icon block>mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </div>
+    </div>
+    <div class="d-block d-md-none">
+      <h2>エリアから探す</h2>
+      <div class="w-283 pa-4">
+        <!--<v-btn @click="backArea()">戻る</v-btn>-->
+        <v-card color="blue" outlined class="pl-2" @click="backArea()">
+          <v-icon>mdi-chevron-left</v-icon>
+          <p class="mb-0"></p>
+        </v-card>
+        <v-card min-height="324" max-width="960" class="pa-6 pt-5" outlined>
+          <v-list dense class="overflow-auto">
+            <v-list-item
+              v-for="(prefecture, i) in prefectures"
+              :key="i"
+              @click="fetchCities(prefecture)"
+            >
+              <v-list-item-content class="text-button">
+                <span class="">{{ prefecture }}</span>
+              </v-list-item-content>
+              <v-list-item-icon>
+                <v-icon block>mdi-chevron-right</v-icon>
+              </v-list-item-icon>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </div>
     </div>
   </div>
 </template>
@@ -34,12 +62,30 @@ export default {
     },
   },
   computed: {
-    ...mapGetters('areaData', ['getPrefectures']),
+    ...mapGetters('areaData', [
+      'getPrefectures',
+      'getCount_prefecture',
+      'getCount_area',
+    ]),
   },
   methods: {
-    ...mapActions('areaData', ['setCities']),
+    ...mapActions('areaData', ['setCities', 'decrement_area']),
     fetchCities(choosePrefecture) {
       this.setCities(choosePrefecture)
+    },
+    displayControll() {
+      if (this.$vuetify.breakpoint.mdAndUp) {
+        return true
+      } else if (
+        (this.$vuetify.breakpoint.smAndDown && this.getCount_prefecture > 1) ||
+        this.getCount_area === 1
+      ) {
+        return false
+      }
+      return true
+    },
+    backArea() {
+      this.decrement_area()
     },
   },
 }

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -20,9 +20,9 @@
         </v-card>
       </div>
     </div>
-    <div class="d-block d-md-none">
-      <h2>エリアから探す</h2>
-      <div class="w-283 pa-4">
+    <div class="d-block d-md-none pa-4">
+      <h3 class="mb-4">エリアを選択してください</h3>
+      <div class="w-283">
         <!--<v-btn @click="backArea()">戻る</v-btn>-->
         <v-card color="blue" outlined class="pl-2" @click="backArea()">
           <v-icon>mdi-chevron-left</v-icon>

--- a/components/ChoosePrefectureCard.vue
+++ b/components/ChoosePrefectureCard.vue
@@ -81,8 +81,15 @@ export default {
     ]),
   },
   methods: {
-    ...mapActions('areaData', ['setCities', 'set_one_area']),
+    ...mapActions('areaData', [
+      'setCities',
+      'set_one_area',
+      'set_one_city',
+      'set_one_prefecture',
+    ]),
     fetchCities(choosePrefecture) {
+      this.set_one_city()
+      this.set_one_prefecture()
       this.setCities(choosePrefecture)
     },
     displayControll() {

--- a/components/SubTitle.vue
+++ b/components/SubTitle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="displayControll()">
     <div class="d-none d-md-block">
       <v-card outlined max-width="990" min-height="245" class="mx-auto">
         <div class="text-center set-color font-weight-black mt-12">
@@ -34,7 +34,22 @@
   </div>
 </template>
 <script>
-export default {}
+import { mapGetters } from 'vuex'
+export default {
+  computed: {
+    ...mapGetters('areaData', ['getCount_area']),
+  },
+  methods: {
+    displayControll() {
+      if (this.$vuetify.breakpoint.mdAndUp) {
+        return true
+      } else if (this.$vuetify.breakpoint.smAndDown && this.getCount_area > 1) {
+        return false
+      }
+      return true
+    },
+  },
+}
 </script>
 <style scoped>
 .fs-28 {

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -1,37 +1,57 @@
-const areas = {
-  hokaido: ['北海道'],
-  touhoku: ['青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県'],
-  koushinetsuHokuriku: [
-    '新潟県',
-    '富山県',
-    '石川県',
-    '福井県',
-    '山梨県',
-    '長野県',
-  ],
-  kanto: [
-    '東京都',
-    '神奈川県',
-    '埼玉県',
-    '千葉県',
-    '茨城県',
-    '栃木県',
-    '群馬県',
-  ],
-  kansai: ['滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県'],
-  tokai: ['岐阜県', '静岡県', '愛知県', '三重県'],
-  tyugoku: ['鳥取県', '島根県', '岡山県', '広島県', '山口県'],
-  shikoku: ['徳島県', '香川県', '愛媛県', '高知県'],
-  kyusyuOkinawa: [
-    '福岡県',
-    '佐賀県',
-    '長崎県',
-    '熊本県',
-    '大分県',
-    '宮崎県',
-    '鹿児島県',
-    '沖縄',
-  ],
+const Areas = {
+  Hokaido: {
+    name: '北海道',
+    prefectures: ['北海道'],
+  },
+  Tohoku: {
+    name: '東北',
+    prefectures: ['青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県'],
+  },
+  KoushinetsuHokuriku: {
+    name: '甲信越北陸',
+    prefectures: ['新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県'],
+  },
+  Kanto: {
+    name: '関東',
+    prefectures: [
+      '東京都',
+      '神奈川県',
+      '埼玉県',
+      '千葉県',
+      '茨城県',
+      '栃木県',
+      '群馬県',
+    ],
+  },
+  Kansai: {
+    name: '関西',
+    prefectures: ['滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県'],
+  },
+  Tokai: {
+    name: '東海',
+    prefectures: ['岐阜県', '静岡県', '愛知県', '三重県'],
+  },
+  Tyugoku: {
+    name: '中国',
+    prefectures: ['鳥取県', '島根県', '岡山県', '広島県', '山口県'],
+  },
+  Shikoku: {
+    name: '四国',
+    prefectures: ['徳島県', '香川県', '愛媛県', '高知県'],
+  },
+  KyusyuOkinawa: {
+    name: '九州沖縄',
+    prefectures: [
+      '福岡県',
+      '佐賀県',
+      '長崎県',
+      '熊本県',
+      '大分県',
+      '宮崎県',
+      '鹿児島県',
+      '沖縄',
+    ],
+  },
 }
 
 const requestMethods = {
@@ -94,23 +114,23 @@ export const actions = {
   setPrefectures({ commit }, chooseArea) {
     commit('increment_area')
     if (chooseArea === '北海道') {
-      commit('setPrefectures', areas.hokaido)
+      commit('setPrefectures', Areas.Hokaido.prefectures)
     } else if (chooseArea === '東北') {
-      commit('setPrefectures', areas.touhoku)
+      commit('setPrefectures', Areas.Tohoku.prefectures)
     } else if (chooseArea === '甲信越北陸') {
-      commit('setPrefectures', areas.koushinetsuHokuriku)
+      commit('setPrefectures', Areas.KoushinetsuHokuriku.prefectures)
     } else if (chooseArea === '関東') {
-      commit('setPrefectures', areas.kanto)
+      commit('setPrefectures', Areas.Kanto.prefectures)
     } else if (chooseArea === '関西') {
-      commit('setPrefectures', areas.kansai)
+      commit('setPrefectures', Areas.Kansai.prefectures)
     } else if (chooseArea === '東海') {
-      commit('setPrefectures', areas.tokai)
+      commit('setPrefectures', Areas.Tokai.prefectures)
     } else if (chooseArea === '中国') {
-      commit('setPrefectures', areas.tyugoku)
+      commit('setPrefectures', Areas.Tyugoku.prefectures)
     } else if (chooseArea === '四国') {
-      commit('setPrefectures', areas.shikoku)
+      commit('setPrefectures', Areas.Shikoku.prefectures)
     } else if (chooseArea === '九州沖縄') {
-      commit('setPrefectures', areas.kyusyuOkinawa)
+      commit('setPrefectures', Areas.KyusyuOkinawa.prefectures)
     }
   },
   setCurrentPrefecture({ commit }, prefecture) {

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -65,6 +65,7 @@ export const state = () => ({
   cities: [],
   count_area: 0,
   count_prefecture: 0,
+  count_city: 0,
 })
 
 export const getters = {
@@ -74,6 +75,7 @@ export const getters = {
   getCities: (state) => state.cities,
   getCount_area: (state) => state.count_area,
   getCount_prefecture: (state) => state.count_prefecture,
+  getCount_city: (state) => state.count_city,
 }
 
 export const mutations = {
@@ -115,6 +117,12 @@ export const mutations = {
   },
   set_one_prefecture(state) {
     state.count_prefecture = 1
+  },
+  increment_city(state) {
+    state.count_city++
+  },
+  set_one_city(state) {
+    state.count_city = 1
   },
 }
 
@@ -189,5 +197,11 @@ export const actions = {
   },
   set_one_prefecture({ commit }) {
     commit('set_one_prefecture')
+  },
+  increment_city({ commit }) {
+    commit('increment_city')
+  },
+  set_one_city({ commit }) {
+    commit('set_one_city')
   },
 }

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -61,12 +61,14 @@ const requestMethods = {
 export const state = () => ({
   prefectures: [],
   currentPrefecture: '',
+  currentArea: '',
   cities: [],
   count_area: 0,
   count_prefecture: 0,
 })
 
 export const getters = {
+  getCurrentArea: (state) => state.currentArea,
   getPrefectures: (state) => state.prefectures,
   getCurrentPrefecture: (state) => state.currentPrefecture,
   getCities: (state) => state.cities,
@@ -75,6 +77,12 @@ export const getters = {
 }
 
 export const mutations = {
+  setCurrentArea(state, area) {
+    state.currentArea = area
+  },
+  clearCurrentArea(state) {
+    state.currentArea = ''
+  },
   setPrefectures(state, prefectures) {
     state.prefectures = prefectures
   },
@@ -111,7 +119,15 @@ export const mutations = {
 }
 
 export const actions = {
+  setCurrentArea({ commit }, chooseArea) {
+    commit('setCurrentPrefecture', chooseArea)
+  },
+  clearCurrentArea({ commit }) {
+    commit('clearCurrentArea')
+  },
   setPrefectures({ commit }, chooseArea) {
+    commit('clearCurrentArea')
+    commit('setCurrentArea', chooseArea)
     commit('increment_area')
     if (chooseArea === '北海道') {
       commit('setPrefectures', Areas.Hokaido.prefectures)

--- a/store/areaData.js
+++ b/store/areaData.js
@@ -101,6 +101,7 @@ export const mutations = {
     state.cities = []
   },
   increment_area(state) {
+    console.log('muataion countup')
     state.count_area++
   },
   decrement_area(state) {
@@ -181,6 +182,7 @@ export const actions = {
     commit('clearCities')
   },
   increment_area({ commit }) {
+    console.log('action countup')
     commit('increment_area')
   },
   decrement_area({ commit }) {


### PR DESCRIPTION
## やったこと

1. エリアカードスマホ対応
2. 県カードスマホ対応
3. 市カードスマホ対応

## やらないこと

1. 背景の色が異なるが、このタスクではやらない
2. 検索窓に入力して、縮めると消える
    - PC→スマホ  スマホ→PC
    - 必須なら、検索窓実装の時に対応する
    [![Image from Gyazo](https://i.gyazo.com/c6cc5f46ea7880831e65e7d25308bc3b.gif)](https://gyazo.com/c6cc5f46ea7880831e65e7d25308bc3b)
3. 一瞬処理が見えてしまうやつ、今の所試して効果なかったやつ 参考サイトあれば教えてほしい
      - clock
      - mounted

## できるようになること（ユーザ目線）

1. スマホからエリアを選択できる
2. 幅を変えても、選択した内容が保持されている.

## できなくなること（ユーザ目線）

なし

## 動作確認
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/specs/)
### frontのみ
```ruby
git fetch && git checkout origin/feature/top-page-responsiv-prefeture-card
```
### 1. `Ctr + c`でサーバーを一旦止める
### 2. `build`する
```ruby
yarn build
```
### 3. 再度立ち上げる
```ruby
yarn dev
```
### 4. 一旦リロードする(ブラウザ)
### 5. 何もせずにスマホサイズへ縮める→エリア選択画面
[![Image from Gyazo](https://i.gyazo.com/dfd1b954de4b6faf6631f30b8bfb4023.gif)](https://gyazo.com/dfd1b954de4b6faf6631f30b8bfb4023)
### 6.エリア選択して縮める→県選択画面 
[![Image from Gyazo](https://i.gyazo.com/aa7ae2fc2bf70cdbff5e1fede03fdeea.gif)](https://gyazo.com/aa7ae2fc2bf70cdbff5e1fede03fdeea)
### 7. 県選択して縮める→市町村選択画面
[![Image from Gyazo](https://i.gyazo.com/3710a08922a248e4404af898fbccdd49.gif)](https://gyazo.com/3710a08922a248e4404af898fbccdd49)
### 8. 市町村選択して縮める→市町村選択画面
[![Image from Gyazo](https://i.gyazo.com/c9773e9f964ba17549b832c7c82c7112.gif)](https://gyazo.com/c9773e9f964ba17549b832c7c82c7112)
### 10. スマホサイズから、エリア選択→県選択画面→市町村選択画面から戻る→県選択画面から戻る→エリア選択画面
[![Image from Gyazo](https://i.gyazo.com/a47435f89e7438530bd78764e1bb895b.gif)](https://gyazo.com/a47435f89e7438530bd78764e1bb895b)
## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
**参考サイトがこうだからではなく、ユーザー視点側からご指摘お願いします。**
参考サイトが〜と言われると必須なのか、必須じゃないのかの判断が難しくなってしまいます。