### PR TITLE
ログイン機能（エンドポイント統一)

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -378,7 +378,7 @@ export default {
   data() {
     return {
       logoutInfo: {
-        redirecttUrl: '/specialists/login',
+        redirectUrl: '/specialists/login',
         valid: false,
       },
       justify: [],

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -75,7 +75,7 @@
               max-width="520"
               min-width="343"
               height="60"
-              @click.prevent="$specialistLogin(loginInfo)"
+              @click.prevent="$login(loginInfo)"
               >ログイン</v-btn
             >
 
@@ -86,7 +86,7 @@
               max-width="520"
               min-width="343"
               height="48"
-              @click.prevent="$specialistLogin(loginInfo)"
+              @click.prevent="$login(loginInfo)"
               >ログイン</v-btn
             >
           </v-card-actions>
@@ -119,7 +119,7 @@ export default {
       loginInfo: {
         email: '',
         password: '',
-        redirecttUrl: '/specialists/users/new',
+        redirectUrl: '/specialists/users/new',
         user_type: 'specialist',
         valid: false,
       },

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -119,7 +119,7 @@ export default {
       loginInfo: {
         email: '',
         password: '',
-        redirecttUrl: '/top',
+        redirectUrl: '/top',
         user_type: 'customer',
         valid: false,
       },

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -3,34 +3,12 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
     login(loginInfo)
   })
 
-  inject('specialistLogin', (loginInfo) => {
-    specialistLogin(loginInfo)
-  })
-
   $axios.onRequest((config) => {
-    if (config.url === '/login' || config.url === '/specialists/login') {
+    if (config.url === '/login') {
       setAuthInfoToHeader(config)
     }
   })
 
-  async function specialistLogin(loginInfo) {
-    try {
-      const response = await $axios.$post('/specialists/login', {
-        email: loginInfo.email,
-        password: loginInfo.password,
-        redirecttUrl: loginInfo.redirecttUrl,
-        user_type: 'specialists',
-        valid: true,
-      })
-      $auth.setUser(true)
-      store.commit('catchErrorMsg/setType', 'success')
-      store.commit('catchErrorMsg/setMsg', ['ログインしました'])
-      redirect(loginInfo.redirecttUrl)
-      return response
-    } catch (error) {
-      return error
-    }
-  }
   async function login(loginInfo) {
     try {
       const response = await $auth.loginWith('local', {
@@ -38,7 +16,7 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
       })
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログインしました'])
-      redirect(loginInfo.redirecttUrl)
+      redirect(loginInfo.redirectUrl)
       return response
     } catch (error) {
       return error


### PR DESCRIPTION
## やったこと

*ログイン時のエンドポイントの統一

## やらないこと

* 特になし
## できるようになること（ユーザ目線）

* エンドポイントを統一することによってフロントでログインの有無を判定できるメソッドが使用でき、レイアウトの表示の切り替えができるようになる

## できなくなること（ユーザ目線）

* 以前のケアマネージャーのログインのエンドポイントが使えなくなります

## 動作確認

## Frontのブランチ切り替え
```ruby
git fetch && git checkout origin/feature/specialists_session
```

## APIのブランチ切り替え
```ruby
git fetch && git checkout origin/feature/specialists_login
```
## カスタマーログイン画面

手順1.`http://localhost:8000/users/login`に移動

「カスタマーがログインできる」
手順2.user_typeがcustomerのemailとパスワードを入力
手順3.カスタマーのTOP画面に遷移する
[手順動画](https://www.loom.com/share/f703b55cae3d417aae6f844735880bc2)

「ケアマネージャーはログインできない」
手順2.user_typeがspecialistのemailとパスワードを入力
手順3.エラーメッセージが表示される
[手順動画](https://www.loom.com/share/9958a04b223c45b1aa36bdaebe4f6805)

## ケアマネージャーログイン画面

手順1.`http://localhost:8000/specialists/login`に移動

「ケアマネージャーがログインできる」
手順2.user_typeがspecialistのemailとパスワードを入力
手順3.ケアマネの新規登録画面に遷移する
[手順動画](https://www.loom.com/share/311aa3d74baa42daad1eb675352a421b)

「カスタマーはログインできない」
手順2.user_typeがcustomerのemailとパスワードを入力
手順3.エラーメッセージが表示される
[手順動画](https://www.loom.com/share/eb1828d91fcd4b3f89daef3fa5e6a018)




## その他

* フロントとAPI合わせて確認お願いします
