### PR TITLE
事業所登録画面完成

### DIFF
--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -1,0 +1,8 @@
+export default async ({ $auth, redirect }) => {
+  // ログイン前ユーザー処理
+  if (!$auth.loggedIn) {
+    // ユーザー以外の値が存在する可能性があるので全てを削除する
+    await $auth.logout()
+    return redirect('/users/login')
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -51,7 +51,7 @@ export default {
 
   // Modules: https://go.nuxtjs.dev/config-modules
 
-  middleware: 'auth',
+  middleware: 'authentication',
 
   modules: [
     // https://axios.nuxtjs.org/setup

--- a/pages/contacts/new.vue
+++ b/pages/contacts/new.vue
@@ -85,11 +85,11 @@ export default {
   data() {
     return {
       items: ['ユーザー', 'ケアマネージャー', '事業所', 'その他'],
-        name: '',
-        email: '',
-        types: '',
-        content: '',
-        valid: false,
+      name: '',
+      email: '',
+      types: '',
+      content: '',
+      valid: false,
       formValidates: {
         required: (value) => !!value || '必須項目です',
         typeCheckString: (value) => {

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -6,13 +6,27 @@
           <v-img :src="office.image_url[active]" height="338">
             <v-row>
               <v-col cols="6">
-                <v-btn class="prev" fab depressed icon @click="prev">
+                <v-btn
+                  class="prev ml-3"
+                  fab
+                  depressed
+                  color="#0000004F"
+                  small
+                  @click="prev"
+                >
                   <v-icon color="white" x-large>mdi-chevron-left</v-icon>
                 </v-btn>
               </v-col>
               <v-col cols="6">
                 <div class="text-right">
-                  <v-btn class="next" fab depressed icon @click="next">
+                  <v-btn
+                    class="next mr-3"
+                    fab
+                    depressed
+                    color="#0000004F"
+                    small
+                    @click="next"
+                  >
                     <v-icon color="white" x-large>mdi-chevron-right</v-icon>
                   </v-btn>
                 </div>
@@ -495,6 +509,7 @@ td {
 
 .prev {
   margin-top: 140px;
+  color: #00000032;
 }
 
 .next {

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -26,13 +26,13 @@
               v-for="index in office.image_url.length"
               :key="index"
               :class="{ current: active === index - 1 }"
+              class="mx-1"
               @click="current(index)"
             >
               <v-img
                 :src="office.image_url[index - 1]"
                 height="50"
                 width="70"
-                class="mx-1"
               ></v-img>
             </li>
           </div>
@@ -486,12 +486,9 @@ td {
   margin-bottom: 16px;
   & li {
     cursor: pointer;
-    opacity: 0.4;
-    &:hover {
-      opacity: 1;
-    }
     &.current {
-      opacity: 1;
+      border: solid;
+      border-color: #f8615e;
     }
   }
 }

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container class="pt-10">
-    {{ staffs.length }}
     <v-row>
       <v-col cols="12" sm="12" md="6">
         <v-card outlined tile height="338">

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -1,19 +1,49 @@
 <template>
   <v-container class="pt-10">
+    {{ staffs.length }}
     <v-row>
       <v-col cols="12" sm="12" md="6">
         <v-card outlined tile height="338">
-          <v-card-title>画像大</v-card-title>
+          <v-img :src="office.image_url[active]" height="338">
+            <v-row>
+              <v-col cols="6">
+                <v-btn class="prev" fab depressed icon @click="prev">
+                  <v-icon color="white" x-large>mdi-chevron-left</v-icon>
+                </v-btn>
+              </v-col>
+              <v-col cols="6">
+                <div class="text-right">
+                  <v-btn class="next" fab depressed icon @click="next">
+                    <v-icon color="white" x-large>mdi-chevron-right</v-icon>
+                  </v-btn>
+                </div>
+              </v-col>
+            </v-row>
+          </v-img>
         </v-card>
         <v-card class="sm-under-no" outlined tile height="85">
-          <v-card-title>事業所画像（小５枚）</v-card-title>
+          <div class="thumbnails">
+            <li
+              v-for="index in office.image_url.length"
+              :key="index"
+              :class="{ current: active === index - 1 }"
+              @click="current(index)"
+            >
+              <v-img
+                :src="office.image_url[index - 1]"
+                height="50"
+                width="70"
+                class="mx-1"
+              ></v-img>
+            </li>
+          </div>
         </v-card>
         <v-card class="md-over-no" outlined tile>
           <v-row class="mx-auto mt-auto max-width">
             <v-col class="office-name" cols="10">{{ office.name }}</v-col>
             <v-col cols="2">
-              <v-btn fab depressed>
-                <v-icon>mdi-star</v-icon>
+              <v-btn fab depressed small>
+                <v-icon color="white">mdi-star</v-icon>
               </v-btn>
             </v-col>
           </v-row>
@@ -31,7 +61,7 @@
             </div>
           </v-col>
           <v-col class="pt-0" md="12" xs="6">
-            <div><v-icon large>mdi-phone</v-icon>{{ office.phone_number }}</div>
+            <v-icon large>mdi-phone</v-icon>{{ office.phone_number }}
             <div class="flex">
               <div class="fax pr-1">FAX</div>
               <div class="my-auto">{{ office.fax_number }}</div>
@@ -136,12 +166,15 @@
               </v-col>
             </v-row>
             <div class="mt-4 md-over-no holiday-detail">
-              営業日の説明が入ります
+              {{ office.business_day_detail }}
             </div>
           </v-col>
         </v-card>
         <v-card class="mt-6" outlined tile height="491">
-          <v-card-title>事業所タイトル</v-card-title>
+          <v-col class="office-title" cols="12">{{ office.title }} </v-col>
+          <v-col class="title_detail" cols="12"
+            >{{ office.title_detail }}
+          </v-col>
         </v-card>
         <v-card class="mt-6" outlined tile height="599">
           <v-card-title> スタッフ紹介 </v-card-title>
@@ -169,7 +202,7 @@
                 <v-icon>mdi-map-marker</v-icon>
                 <div class="my-auto">東京駅 徒歩5分</div>
                 <v-icon>mdi-account</v-icon>
-                <div class="my-auto">スタッフ数 5人</div>
+                <div class="my-auto">スタッフ数 {{ staffs.length }}人</div>
               </div>
             </v-col>
             <v-col class="pt-0" md="12" xs="6">
@@ -292,13 +325,17 @@ export default {
   data() {
     return {
       office_id: this.$route.params.id,
+      active: 0, // 事業所画像が現在何番目か
       office: {
         selected_flags: '',
+        image_url: [],
       },
+      staffs: {},
     }
   },
   mounted() {
     this.getOffice()
+    this.getStaffs()
   },
   methods: {
     async getOffice() {
@@ -307,6 +344,40 @@ export default {
         this.office = response
       } catch (error) {
         return error
+      }
+    },
+    async getStaffs() {
+      try {
+        const response = await this.$axios.$get(
+          `specialists/offices/${this.office_id}/staffs`
+        )
+        this.staffs = response
+      } catch (error) {
+        return error
+      }
+    },
+    // サムネイルをクリックしたらその番号にする
+    // indexは1から始まるので、-1として配列の番号と合わせる
+    current(index) {
+      this.active = index - 1
+    },
+    // 左矢印（前へ）
+    prev() {
+      // activeが0以下なら一番最後の画像へもどる
+      if (this.active <= 0) {
+        this.active = this.office.image_url.length - 1
+      } else {
+        this.active--
+      }
+    },
+    // 右矢印（次へ）
+    next() {
+      // 配列の数が0~5つで6つになるので、-1とする
+      // 5番目のときにnextしたら0番目に戻る
+      if (this.active >= this.office.image_url.length - 1) {
+        this.active = 0
+      } else {
+        this.active++
       }
     },
   },
@@ -341,24 +412,19 @@ td {
   border-right: 1px solid #e0e0e0;
   border-bottom: 1px solid #e0e0e0;
   box-shadow: 1px 1px 0 0 #fff inset, -1px -1px 0 0 #fff inset;
-  padding: 4px 12px;
-}
-
-.even {
-  background-color: #fafafa;
 }
 
 .flex {
   display: flex;
 }
 
-.height {
-  max-height: none;
-  min-height: min-content;
-}
-
 .office-tel {
   font-size: 13px;
+  color: #707f89;
+}
+
+.title_detail {
+  font-size: 14px;
   color: #707f89;
 }
 
@@ -386,6 +452,11 @@ td {
   color: #707f89;
 }
 
+.office-title {
+  font-size: 20px;
+  font-weight: bold;
+}
+
 @media screen and (max-width: 959px) {
   /* sm以下で表示しない */
   .sm-under-no {
@@ -405,6 +476,53 @@ td {
   .office-name {
     font-size: 28px;
     font-weight: bold;
+  }
+}
+
+.thumbnails {
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  & li {
+    cursor: pointer;
+    opacity: 0.4;
+    &:hover {
+      opacity: 1;
+    }
+    &.current {
+      opacity: 1;
+    }
+  }
+}
+
+.prev {
+  margin-top: 140px;
+}
+
+.next {
+  margin-top: 140px;
+}
+
+.active {
+  &-enter {
+    opacity: 0;
+    &-to {
+      opacity: 1;
+    }
+    &-active {
+      transition: opacity 0.5s;
+    }
+  }
+  &-leave {
+    opacity: 1;
+    &-to {
+      opacity: 0;
+    }
+    &-active {
+      transition: opacity 0.5s;
+    }
   }
 }
 </style>

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -508,12 +508,11 @@ td {
 }
 
 .prev {
-  margin-top: 140px;
-  color: #00000032;
+  margin-top: 150px;
 }
 
 .next {
-  margin-top: 140px;
+  margin-top: 150px;
 }
 
 .active {

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -70,7 +70,7 @@
               <v-icon>mdi-map-marker</v-icon>
               <div class="my-auto">東京駅 徒歩5分</div>
               <v-icon>mdi-account</v-icon>
-              <div class="my-auto">スタッフ数 5人</div>
+              <div class="my-auto">スタッフ数 {{ staffs.length }}人</div>
             </div>
           </v-col>
           <v-col class="pt-0" md="12" xs="6">

--- a/pages/offices/_id.vue
+++ b/pages/offices/_id.vue
@@ -289,15 +289,26 @@
 <script>
 export default {
   layout: 'application',
-  async asyncData({ $axios, params }) {
-    let office = []
-    const id = `${params.id}`
-    await $axios.$get(`offices/${id}`).then((res) => (office = res))
-    return { office }
-  },
-
   data() {
-    return {}
+    return {
+      office_id: this.$route.params.id,
+      office: {
+        selected_flags: '',
+      },
+    }
+  },
+  mounted() {
+    this.getOffice()
+  },
+  methods: {
+    async getOffice() {
+      try {
+        const response = await this.$axios.$get(`offices/${this.office_id}`)
+        this.office = response
+      } catch (error) {
+        return error
+      }
+    },
   },
 }
 </script>

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -119,7 +119,7 @@ export default {
       loginInfo: {
         email: '',
         password: '',
-        redirectUrl: '/specialists/users/new',
+        redirectUrl: '/specialists/office/new',
         user_type: 'specialist',
         valid: false,
       },

--- a/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
@@ -94,6 +94,7 @@
 <script>
 export default {
   layout: 'application_specialists',
+  middleware: 'authentication',
   data() {
     return {
       formValidates: {

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -64,6 +64,7 @@
 <script>
 export default {
   layout: 'application_specialists',
+  middleware: 'authentication',
   data() {
     return {
       staffs: [],

--- a/pages/specialists/office/_office_id/staffs/new.vue
+++ b/pages/specialists/office/_office_id/staffs/new.vue
@@ -90,6 +90,7 @@
 <script>
 export default {
   layout: 'application_specialists',
+  middleware: 'authentication',
   data() {
     return {
       formValidates: {
@@ -130,8 +131,6 @@ export default {
         await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
-        this.$store.commit('catchErrorMsg/setType', 'success')
-        this.$store.commit('catchErrorMsg/setMsg', ['登録しました'])
         this.$router.push('.')
       } catch (error) {
         return error

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -273,12 +273,12 @@ export default {
     },
     images: {
       handler() {
-        console.log(this.images.length)
+        console.log(this.images[0])
       },
     },
   },
   methods: {
-    async send() {
+    send() {
       if (this.selected.includes('日')) {
         this.flags += 1
       }
@@ -329,8 +329,11 @@ export default {
       params.append('fax_number', this.fax_number)
       params.append('post_code', this.post_code)
       params.append('address', this.address)
+      console.log(params)
       try {
-        await this.$axios.$post(`offices`, params)
+        await this.$axios.$post(`offices`, params, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        })
       } catch (error) {
         return error
       }

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -204,6 +204,7 @@
 <script>
 export default {
   layout: 'application_specialists',
+  middleware: 'authentication',
   data() {
     return {
       formValidates: {

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -26,6 +26,17 @@
               dense
               height="44"
           /></label>
+          <v-file-input
+            v-model="officeImages"
+            multiple
+            :rules="[formValidates.fileSizeCheck]"
+            truncate-length="20"
+            accept="image/*"
+            prepend-icon="mdi-camera"
+            label="事業所画像をアップロードする"
+            class="image-form"
+          >
+          </v-file-input>
           <label class="font-color-gray font-weight-black text-caption"
             >休業日
           </label>
@@ -180,6 +191,11 @@ export default {
           value.length <= 30 || '30文字以下で入力してください',
         titleCountCheck: (value) =>
           value.length <= 50 || '50文字以下で入力してください',
+        fileSizeCheck: (value) => {
+          console.log(`value.log:::${value}`)
+          console.log(`valueLength.log:::${value.length}`)
+          console.log(`valueSize.log:::${value.size}`)
+        },
         businessDayDetailCountCheck: (value) =>
           value.length <= 120 || '120文字以下で入力してください',
         phoneNumber: (value) => {
@@ -195,6 +211,7 @@ export default {
       },
       name: '',
       title: '',
+      officeImages: [],
       flags: 0,
       business_day_detail: '',
       phone_number: '',
@@ -228,7 +245,25 @@ export default {
       if (this.selected.includes('土')) {
         this.flags += 64
       }
-      // console.log(this.flags)
+      const params = new FormData()
+      const officeImagesNum = this.officeImages.length
+      params.append('name', this.name)
+      params.append('title', this.title)
+      if (officeImagesNum >= 6) {
+        this.$store.commit('catchErrorMsg/setType', 'error')
+        this.$store.commit('catchErrorMsg/setMsg', [
+          '事業所画像は5枚以下でアップロードしてください',
+        ])
+      } else {
+        params.append('officeImages', this.officeImages)
+      }
+      params.append('flags', this.flags)
+      params.append('business_day_detail', this.business_day_detail)
+      params.append('phone_number', this.phone_number)
+      params.append('fax_number', this.fax_number)
+      params.append('post_code', this.post_code)
+      params.append('address', this.address)
+      console.log(officeImagesNum)
       this.flags = 0
     },
   },
@@ -251,5 +286,9 @@ input[type='checkbox'] {
 
 .post-form >>> .v-text-field__slot {
   max-width: 82px;
+}
+
+.image-form >>> .v-input__slot {
+  width: 300px;
 }
 </style>

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -225,10 +225,6 @@ export default {
             console.log(fileArray)
             console.log(typeof fileArray) */
           })
-          if (imageFlag === false) {
-            imageFlag = true
-            this.images = image
-          }
           return true
         },
         fileLengthCheck: (value) =>

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -26,20 +26,6 @@
               dense
               height="44"
           /></label>
-          <v-file-input
-            v-model="images"
-            multiple
-            :rules="[
-              formValidates.fileSizeCheck,
-              formValidates.fileLengthCheck,
-            ]"
-            truncate-length="30"
-            accept="image/*"
-            prepend-icon="mdi-camera"
-            label="事業所画像をアップロード（5枚まで）"
-            class="image-form"
-          >
-          </v-file-input>
           <label class="font-color-gray font-weight-black text-caption"
             >休業日
           </label>
@@ -115,7 +101,7 @@
               </v-checkbox>
             </v-col>
           </v-row>
-          <div v-show="isShow" class="error-text mb-3">
+          <div v-show="isShow" class="holiday-error-text mb-3">
             休業日を選択してください
           </div>
           <label class="font-color-gray font-weight-black text-caption"
@@ -149,13 +135,14 @@
             >FAX
             <v-text-field
               v-model="fax_number"
-              :rules="[formValidates.required, formValidates.phoneNumber]"
-              class="mt-2 font-weight-regular"
+              :rules="[formValidates.faxNumber]"
+              class="mt-2 mb-2 font-weight-regular"
               placeholder="090-8765-4321"
               outlined
               dense
               height="44"
-          /></label>
+            /><!-- <div v-show="faxErrorIsShow" class="fax-error-text">正しいFAXではありません</div> --></label
+          >
         </v-col>
         <v-text-field
           v-model="post_code"
@@ -176,6 +163,7 @@
           <div class="mt-n2">
             <v-text-field
               v-model="address"
+              :rules="[formValidates.required]"
               outlined
               dense
               height="44"
@@ -211,19 +199,19 @@ export default {
           value.length <= 30 || '30文字以下で入力してください',
         titleCountCheck: (value) =>
           value.length <= 50 || '50文字以下で入力してください',
-        fileSizeCheck: (values) =>
+        /* fileSizeCheck: (values) =>
           !values ||
           !values.some((value) => value.size >= 10000000) ||
           '画像サイズは10MB以下でアップロードしてください',
         fileLengthCheck: (value) =>
-          value.length <= 5 || '画像は5枚以下にしてください',
+          value.length <= 5 || '画像は5枚以下にしてください', */
         holidayLengthCheck: (values) => {
-          const arry = []
+          const array = []
           Array.prototype.forEach.call(Object(values), (value) => {
-            arry.push(value)
+            array.push(value)
             this.isShow = false
           })
-          return arry.length >= 1
+          return array.length >= 1
         },
         businessDayDetailCountCheck: (value) =>
           value.length <= 120 || '120文字以下で入力してください',
@@ -231,6 +219,14 @@ export default {
           const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
           return format.test(value) || '正しい電話番号ではありません'
         },
+        faxNumber: (value) =>
+          value === '' || value.match(/^\d{2,4}-\d{2,4}-\d{4}$/g) || 'test',
+        /* if(value === '' || value.match(/^\d{2,4}-\d{2,4}-\d{4}$/g)){
+          this.faxErrorIsShow = false
+          console.log(this.valid)
+        }else{
+          return 'test'
+        } */
         postCode: (value) => {
           const format = /^[0-9]{3}-[0-9]{4}$/g
           return (
@@ -240,8 +236,6 @@ export default {
       },
       name: '',
       title: '',
-      images: [],
-      parseImages: [],
       flags: 0,
       business_day_detail: '',
       phone_number: '',
@@ -251,7 +245,7 @@ export default {
       selected: [],
       valid: false,
       isShow: true,
-      user_id: '2',
+      faxErrorIsShow: false,
     }
   },
   watch: {
@@ -262,6 +256,25 @@ export default {
         }
       },
     },
+    /* fax_number:{
+      handler(){
+        if(this.fax_number === '' || this.fax_number.match(/^\d{2,4}-\d{2,4}-\d{4}$/g)){
+          this.faxErrorIsShow = false
+          console.log(this.valid)
+        }else{
+          this.faxErrorIsShow = true
+          this.valid = false
+          console.log(this.valid)
+        }
+      }
+    }, */
+    /* faxErrorIsShow:{
+      handler(){
+        if(this.faxErrorIsShow === false){
+          this.
+        }
+      }
+    } */
   },
   methods: {
     async send() {
@@ -286,13 +299,9 @@ export default {
       if (this.selected.includes('土')) {
         this.flags += 64
       }
-      /* for (let i = 0; i <= this.images.length; i++) {
-        this.images = 
-      } */
       const params = new FormData()
       params.append('name', this.name)
       params.append('title', this.title)
-      params.append('images', this.images)
       params.append('flags', this.flags)
       params.append('business_day_detail', this.business_day_detail)
       params.append('phone_number', this.phone_number)
@@ -300,9 +309,7 @@ export default {
       params.append('post_code', this.post_code)
       params.append('address', this.address)
       try {
-        await this.$axios.$post(`offices`, params, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-        })
+        await this.$axios.$post(`offices`, params)
       } catch (error) {
         return error
       }
@@ -321,9 +328,13 @@ input[type='checkbox'] {
   margin: 0 6px 0 0;
 }
 
-.error-text {
+.holiday-error-text {
   color: red;
   text-align: center;
+}
+
+.fax-error-text {
+  color: #fc7569;
 }
 
 /* stylelint-disable */

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -271,6 +271,11 @@ export default {
         console.log(this.selected)
       },
     },
+    images: {
+      handler() {
+        console.log(this.images.length)
+      },
+    },
   },
   methods: {
     async send() {
@@ -295,23 +300,26 @@ export default {
       if (this.selected.includes('土')) {
         this.flags += 64
       }
+      const params = new FormData()
       const array = []
       Array.prototype.forEach.call(Object(this.images), (value) => {
         array.push(value)
         console.log(`arry::${array}`)
         console.log(array)
         console.log(typeof array)
-        this.isShow = false
       })
-      /* console.log(`for前のlength::${this.images.length}`)
-      for(let i = 0; i <= this.images.length; i++){
-              this.images = this.images[i]
+      // console.log(`for前のlength::${this.images.length}`)
+      /* for(let i = 0; i <= 5; i++){
+        if(this.images[i] === null){
+          continue
+        }
+        params.append('images', this.images[i])
+              // this.images = this.images[i]
               console.log(i)
-              console.log(`for最中のlength::${this.images.length}`)
-              console.log(this.images)
+              // console.log(`for最中のlength::${this.images.length}`)
+              console.log(this.images[i])
               console.log('発火')
         } */
-      const params = new FormData()
       params.append('name', this.name)
       params.append('title', this.title)
       params.append('images', array)

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -29,11 +29,7 @@
           <v-file-input
             v-model="images"
             multiple
-            :rules="[
-              formValidates.fileSizeCheck,
-              formValidates.fileLengthCheck,
-              formValidates.file,
-            ]"
+            :rules="[formValidates.fileLengthCheck]"
             truncate-length="30"
             accept="image/*"
             prepend-icon="mdi-camera"
@@ -213,20 +209,10 @@ export default {
           value.length <= 30 || '30文字以下で入力してください',
         titleCountCheck: (value) =>
           value.length <= 50 || '50文字以下で入力してください',
-        fileSizeCheck: (values) =>
+        /* fileSizeCheck: (values) =>
           !values ||
           !values.some((value) => value.size >= 10000000) ||
-          '画像サイズは10MB以下でアップロードしてください',
-        file: (values) => {
-          const fileArray = []
-          Array.prototype.forEach.call(Object(values), (value) => {
-            fileArray.push(value)
-            /* console.log(`array::${fileArray}`)
-            console.log(fileArray)
-            console.log(typeof fileArray) */
-          })
-          return true
-        },
+          '画像サイズは10MB以下でアップロードしてください', */
         fileLengthCheck: (value) =>
           value.length <= 5 || '画像は5枚以下にしてください',
         holidayLengthCheck: (values) => {
@@ -263,6 +249,7 @@ export default {
       name: '',
       title: '',
       images: [],
+      imageArray: [],
       flags: 0,
       business_day_detail: '',
       phone_number: '',
@@ -282,15 +269,6 @@ export default {
           this.isShow = true
         }
         console.log(this.selected)
-      },
-    },
-    fileArray: {
-      handler() {
-        /* Array.prototype.forEach.call(Object(this.images), (image) => {
-            this.array.push(image)
-            console.log('発火')
-          }) */
-        console.log(fileArray)
       },
     },
   },
@@ -317,10 +295,26 @@ export default {
       if (this.selected.includes('土')) {
         this.flags += 64
       }
+      const array = []
+      Array.prototype.forEach.call(Object(this.images), (value) => {
+        array.push(value)
+        console.log(`arry::${array}`)
+        console.log(array)
+        console.log(typeof array)
+        this.isShow = false
+      })
+      /* console.log(`for前のlength::${this.images.length}`)
+      for(let i = 0; i <= this.images.length; i++){
+              this.images = this.images[i]
+              console.log(i)
+              console.log(`for最中のlength::${this.images.length}`)
+              console.log(this.images)
+              console.log('発火')
+        } */
       const params = new FormData()
       params.append('name', this.name)
       params.append('title', this.title)
-      params.append('images', this.images)
+      params.append('images', array)
       params.append('flags', this.flags)
       params.append('business_day_detail', this.business_day_detail)
       params.append('phone_number', this.phone_number)

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -27,16 +27,16 @@
               height="44"
           /></label>
           <v-file-input
-            v-model="officeImages"
+            v-model="images"
             multiple
             :rules="[
               formValidates.fileSizeCheck,
               formValidates.fileLengthCheck,
             ]"
-            truncate-length="20"
+            truncate-length="30"
             accept="image/*"
             prepend-icon="mdi-camera"
-            label="事業所画像をアップロードする"
+            label="事業所画像をアップロード（5枚まで）"
             class="image-form"
           >
           </v-file-input>
@@ -44,27 +44,80 @@
             >休業日
           </label>
           <v-row class="mt-2 mb-2 mx-auto">
-            <label class="ml-3">日</label>
-            <v-checkbox
-              v-model="selected"
-              :rules="[formValidates.holidayLengthCheck]"
-              value="日"
-              class=""
-            >
-            </v-checkbox>
-            <label class="ml-3">日</label>
-            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
-            <label class="ml-3">日</label>
-            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
-            <label class="ml-3">日</label>
-            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
-            <label class="ml-3">日</label>
-            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
-            <label class="ml-3">日</label>
-            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
-            <label class="ml-3">日</label>
-            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
+            <v-col cols="1" class="mx-5"
+              ><div class="ml-1">日</div>
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="日"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
+            <v-col cols="1" class="mx-5"
+              >月
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="月"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
+            <v-col cols="1" class="mx-5"
+              >火
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="火"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
+            <v-col cols="1" class="mx-5"
+              >水
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="水"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
+            <v-col cols="1" class="mx-5"
+              >木
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="木"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
+            <v-col cols="1" class="mx-5"
+              >金
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="金"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
+            <v-col cols="1" class="mx-5"
+              >土
+              <v-checkbox
+                v-model="selected"
+                :rules="[formValidates.holidayLengthCheck]"
+                value="土"
+                class="mr-3"
+              >
+              </v-checkbox>
+            </v-col>
           </v-row>
+          <div v-show="isShow" class="error-text mb-3">
+            休業日を選択してください
+          </div>
           <label class="font-color-gray font-weight-black text-caption"
             >営業日に関する説明
             <v-textarea
@@ -164,8 +217,14 @@ export default {
           '画像サイズは10MB以下でアップロードしてください',
         fileLengthCheck: (value) =>
           value.length <= 5 || '画像は5枚以下にしてください',
-        holidayLengthCheck: (value) =>
-          value.length === 0 || '50文字以下で入力してください',
+        holidayLengthCheck: (values) => {
+          const arry = []
+          Array.prototype.forEach.call(Object(values), (value) => {
+            arry.push(value)
+            this.isShow = false
+          })
+          return arry.length >= 1
+        },
         businessDayDetailCountCheck: (value) =>
           value.length <= 120 || '120文字以下で入力してください',
         phoneNumber: (value) => {
@@ -181,7 +240,8 @@ export default {
       },
       name: '',
       title: '',
-      officeImages: [],
+      images: [],
+      parseImages: [],
       flags: 0,
       business_day_detail: '',
       phone_number: '',
@@ -190,17 +250,21 @@ export default {
       address: '',
       selected: [],
       valid: false,
+      isShow: true,
+      user_id: '2',
     }
   },
   watch: {
     selected: {
       handler() {
-        console.log(this.selected)
+        if (this.selected.length === 0) {
+          this.isShow = true
+        }
       },
     },
   },
   methods: {
-    send() {
+    async send() {
       if (this.selected.includes('日')) {
         this.flags += 1
       }
@@ -222,16 +286,26 @@ export default {
       if (this.selected.includes('土')) {
         this.flags += 64
       }
+      /* for (let i = 0; i <= this.images.length; i++) {
+        this.images = 
+      } */
       const params = new FormData()
       params.append('name', this.name)
       params.append('title', this.title)
-      params.append('officeImages', this.officeImages)
+      params.append('images', this.images)
       params.append('flags', this.flags)
       params.append('business_day_detail', this.business_day_detail)
       params.append('phone_number', this.phone_number)
       params.append('fax_number', this.fax_number)
       params.append('post_code', this.post_code)
       params.append('address', this.address)
+      try {
+        await this.$axios.$post(`offices`, params, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        })
+      } catch (error) {
+        return error
+      }
       this.flags = 0
     },
   },
@@ -247,6 +321,11 @@ input[type='checkbox'] {
   margin: 0 6px 0 0;
 }
 
+.error-text {
+  color: red;
+  text-align: center;
+}
+
 /* stylelint-disable */
 .post-form >>> fieldset {
   width: 107px;
@@ -257,6 +336,6 @@ input[type='checkbox'] {
 }
 
 .image-form >>> .v-input__slot {
-  width: 300px;
+  width: 320px;
 }
 </style>

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -26,6 +26,21 @@
               dense
               height="44"
           /></label>
+          <v-file-input
+            v-model="images"
+            multiple
+            :rules="[
+              formValidates.fileSizeCheck,
+              formValidates.fileLengthCheck,
+              formValidates.file,
+            ]"
+            truncate-length="30"
+            accept="image/*"
+            prepend-icon="mdi-camera"
+            label="事業所画像をアップロード（5枚まで）"
+            class="image-form"
+          >
+          </v-file-input>
           <label class="font-color-gray font-weight-black text-caption"
             >休業日
           </label>
@@ -141,8 +156,7 @@
               outlined
               dense
               height="44"
-            /><!-- <div v-show="faxErrorIsShow" class="fax-error-text">正しいFAXではありません</div> --></label
-          >
+          /></label>
         </v-col>
         <v-text-field
           v-model="post_code"
@@ -199,19 +213,36 @@ export default {
           value.length <= 30 || '30文字以下で入力してください',
         titleCountCheck: (value) =>
           value.length <= 50 || '50文字以下で入力してください',
-        /* fileSizeCheck: (values) =>
+        fileSizeCheck: (values) =>
           !values ||
           !values.some((value) => value.size >= 10000000) ||
           '画像サイズは10MB以下でアップロードしてください',
+        file: (values) => {
+          const fileArray = []
+          Array.prototype.forEach.call(Object(values), (value) => {
+            fileArray.push(value)
+            /* console.log(`array::${fileArray}`)
+            console.log(fileArray)
+            console.log(typeof fileArray) */
+          })
+          if (imageFlag === false) {
+            imageFlag = true
+            this.images = image
+          }
+          return true
+        },
         fileLengthCheck: (value) =>
-          value.length <= 5 || '画像は5枚以下にしてください', */
+          value.length <= 5 || '画像は5枚以下にしてください',
         holidayLengthCheck: (values) => {
           const array = []
           Array.prototype.forEach.call(Object(values), (value) => {
             array.push(value)
+            /* console.log(`arry::${array}`)
+            console.log(array)
+            console.log(typeof array) */
             this.isShow = false
           })
-          return array.length >= 1
+          return values.length >= 1
         },
         businessDayDetailCountCheck: (value) =>
           value.length <= 120 || '120文字以下で入力してください',
@@ -219,14 +250,13 @@ export default {
           const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
           return format.test(value) || '正しい電話番号ではありません'
         },
-        faxNumber: (value) =>
-          value === '' || value.match(/^\d{2,4}-\d{2,4}-\d{4}$/g) || 'test',
-        /* if(value === '' || value.match(/^\d{2,4}-\d{2,4}-\d{4}$/g)){
-          this.faxErrorIsShow = false
-          console.log(this.valid)
-        }else{
-          return 'test'
-        } */
+        faxNumber: (value) => {
+          if (value === '' || value.match(/^\d{2,4}-\d{2,4}-\d{4}$/g)) {
+            return true
+          } else {
+            return '正しいFAXではありません'
+          }
+        },
         postCode: (value) => {
           const format = /^[0-9]{3}-[0-9]{4}$/g
           return (
@@ -236,6 +266,7 @@ export default {
       },
       name: '',
       title: '',
+      images: [],
       flags: 0,
       business_day_detail: '',
       phone_number: '',
@@ -244,8 +275,8 @@ export default {
       address: '',
       selected: [],
       valid: false,
+      imageFlag: false,
       isShow: true,
-      faxErrorIsShow: false,
     }
   },
   watch: {
@@ -254,27 +285,18 @@ export default {
         if (this.selected.length === 0) {
           this.isShow = true
         }
+        console.log(this.selected)
       },
     },
-    /* fax_number:{
-      handler(){
-        if(this.fax_number === '' || this.fax_number.match(/^\d{2,4}-\d{2,4}-\d{4}$/g)){
-          this.faxErrorIsShow = false
-          console.log(this.valid)
-        }else{
-          this.faxErrorIsShow = true
-          this.valid = false
-          console.log(this.valid)
-        }
-      }
-    }, */
-    /* faxErrorIsShow:{
-      handler(){
-        if(this.faxErrorIsShow === false){
-          this.
-        }
-      }
-    } */
+    fileArray: {
+      handler() {
+        /* Array.prototype.forEach.call(Object(this.images), (image) => {
+            this.array.push(image)
+            console.log('発火')
+          }) */
+        console.log(fileArray)
+      },
+    },
   },
   methods: {
     async send() {
@@ -302,6 +324,7 @@ export default {
       const params = new FormData()
       params.append('name', this.name)
       params.append('title', this.title)
+      params.append('images', this.images)
       params.append('flags', this.flags)
       params.append('business_day_detail', this.business_day_detail)
       params.append('phone_number', this.phone_number)
@@ -331,10 +354,6 @@ input[type='checkbox'] {
 .holiday-error-text {
   color: red;
   text-align: center;
-}
-
-.fax-error-text {
-  color: #fc7569;
 }
 
 /* stylelint-disable */

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -308,7 +308,7 @@ export default {
       params.append('post_code', this.post_code)
       params.append('address', this.address)
       try {
-        await this.$axios.$post(`offices`, params, {
+        await this.$axios.$post(`specialists/offices`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
       } catch (error) {

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -278,7 +278,7 @@ export default {
     },
   },
   methods: {
-    send() {
+    async send() {
       if (this.selected.includes('日')) {
         this.flags += 1
       }

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -29,7 +29,10 @@
           <v-file-input
             v-model="images"
             multiple
-            :rules="[formValidates.fileLengthCheck]"
+            :rules="[
+              formValidates.fileLengthCheck,
+              formValidates.fileSizeCheck,
+            ]"
             truncate-length="30"
             accept="image/*"
             prepend-icon="mdi-camera"
@@ -209,19 +212,16 @@ export default {
           value.length <= 30 || '30文字以下で入力してください',
         titleCountCheck: (value) =>
           value.length <= 50 || '50文字以下で入力してください',
-        /* fileSizeCheck: (values) =>
+        fileSizeCheck: (values) =>
           !values ||
           !values.some((value) => value.size >= 10000000) ||
-          '画像サイズは10MB以下でアップロードしてください', */
+          '画像サイズは10MB以下でアップロードしてください',
         fileLengthCheck: (value) =>
           value.length <= 5 || '画像は5枚以下にしてください',
         holidayLengthCheck: (values) => {
           const array = []
           Array.prototype.forEach.call(Object(values), (value) => {
             array.push(value)
-            /* console.log(`arry::${array}`)
-            console.log(array)
-            console.log(typeof array) */
             this.isShow = false
           })
           return values.length >= 1
@@ -249,7 +249,6 @@ export default {
       name: '',
       title: '',
       images: [],
-      imageArray: [],
       flags: 0,
       business_day_detail: '',
       phone_number: '',
@@ -258,7 +257,6 @@ export default {
       address: '',
       selected: [],
       valid: false,
-      imageFlag: false,
       isShow: true,
     }
   },
@@ -268,12 +266,6 @@ export default {
         if (this.selected.length === 0) {
           this.isShow = true
         }
-        console.log(this.selected)
-      },
-    },
-    images: {
-      handler() {
-        console.log(this.images[0])
       },
     },
   },
@@ -301,35 +293,20 @@ export default {
         this.flags += 64
       }
       const params = new FormData()
-      const array = []
-      Array.prototype.forEach.call(Object(this.images), (value) => {
-        array.push(value)
-        console.log(`arry::${array}`)
-        console.log(array)
-        console.log(typeof array)
-      })
-      // console.log(`for前のlength::${this.images.length}`)
-      /* for(let i = 0; i <= 5; i++){
-        if(this.images[i] === null){
-          continue
-        }
-        params.append('images', this.images[i])
-              // this.images = this.images[i]
-              console.log(i)
-              // console.log(`for最中のlength::${this.images.length}`)
-              console.log(this.images[i])
-              console.log('発火')
-        } */
       params.append('name', this.name)
       params.append('title', this.title)
-      params.append('images', array)
+      for (let index = 0; index <= 5; index++) {
+        if (this.images[index] === undefined) {
+          continue
+        }
+        params.append('images[]', this.images[index])
+      }
       params.append('flags', this.flags)
       params.append('business_day_detail', this.business_day_detail)
       params.append('phone_number', this.phone_number)
       params.append('fax_number', this.fax_number)
       params.append('post_code', this.post_code)
       params.append('address', this.address)
-      console.log(params)
       try {
         await this.$axios.$post(`offices`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -29,7 +29,10 @@
           <v-file-input
             v-model="officeImages"
             multiple
-            :rules="[formValidates.fileSizeCheck]"
+            :rules="[
+              formValidates.fileSizeCheck,
+              formValidates.fileLengthCheck,
+            ]"
             truncate-length="20"
             accept="image/*"
             prepend-icon="mdi-camera"
@@ -41,62 +44,26 @@
             >休業日
           </label>
           <v-row class="mt-2 mb-2 mx-auto">
-            <v-col cols="1" class="mx-5"
-              ><label
-                >日<input
-                  v-model="selected"
-                  value="日"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
-            <v-col cols="1" class="mx-5"
-              ><label
-                >月<input
-                  v-model="selected"
-                  value="月"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
-            <v-col cols="1" class="mx-5"
-              ><label
-                >火<input
-                  v-model="selected"
-                  value="火"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
-            <v-col cols="1" class="mx-5"
-              ><label
-                >水<input
-                  v-model="selected"
-                  value="水"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
-            <v-col cols="1" class="mx-5"
-              ><label
-                >木<input
-                  v-model="selected"
-                  value="木"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
-            <v-col cols="1" class="mx-5"
-              ><label
-                >金<input
-                  v-model="selected"
-                  value="金"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
-            <v-col cols="1" class="mx-5"
-              ><label
-                >土<input
-                  v-model="selected"
-                  value="土"
-                  type="checkbox"
-                  class="mr-3" /></label
-            ></v-col>
+            <label class="ml-3">日</label>
+            <v-checkbox
+              v-model="selected"
+              :rules="[formValidates.holidayLengthCheck]"
+              value="日"
+              class=""
+            >
+            </v-checkbox>
+            <label class="ml-3">日</label>
+            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
+            <label class="ml-3">日</label>
+            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
+            <label class="ml-3">日</label>
+            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
+            <label class="ml-3">日</label>
+            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
+            <label class="ml-3">日</label>
+            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
+            <label class="ml-3">日</label>
+            <v-checkbox v-model="selected" value="日" class=""> </v-checkbox>
           </v-row>
           <label class="font-color-gray font-weight-black text-caption"
             >営業日に関する説明
@@ -191,11 +158,14 @@ export default {
           value.length <= 30 || '30文字以下で入力してください',
         titleCountCheck: (value) =>
           value.length <= 50 || '50文字以下で入力してください',
-        fileSizeCheck: (value) => {
-          console.log(`value.log:::${value}`)
-          console.log(`valueLength.log:::${value.length}`)
-          console.log(`valueSize.log:::${value.size}`)
-        },
+        fileSizeCheck: (values) =>
+          !values ||
+          !values.some((value) => value.size >= 10000000) ||
+          '画像サイズは10MB以下でアップロードしてください',
+        fileLengthCheck: (value) =>
+          value.length <= 5 || '画像は5枚以下にしてください',
+        holidayLengthCheck: (value) =>
+          value.length === 0 || '50文字以下で入力してください',
         businessDayDetailCountCheck: (value) =>
           value.length <= 120 || '120文字以下で入力してください',
         phoneNumber: (value) => {
@@ -222,6 +192,13 @@ export default {
       valid: false,
     }
   },
+  watch: {
+    selected: {
+      handler() {
+        console.log(this.selected)
+      },
+    },
+  },
   methods: {
     send() {
       if (this.selected.includes('日')) {
@@ -246,24 +223,15 @@ export default {
         this.flags += 64
       }
       const params = new FormData()
-      const officeImagesNum = this.officeImages.length
       params.append('name', this.name)
       params.append('title', this.title)
-      if (officeImagesNum >= 6) {
-        this.$store.commit('catchErrorMsg/setType', 'error')
-        this.$store.commit('catchErrorMsg/setMsg', [
-          '事業所画像は5枚以下でアップロードしてください',
-        ])
-      } else {
-        params.append('officeImages', this.officeImages)
-      }
+      params.append('officeImages', this.officeImages)
       params.append('flags', this.flags)
       params.append('business_day_detail', this.business_day_detail)
       params.append('phone_number', this.phone_number)
       params.append('fax_number', this.fax_number)
       params.append('post_code', this.post_code)
       params.append('address', this.address)
-      console.log(officeImagesNum)
       this.flags = 0
     },
   },

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -10,7 +10,7 @@ export default function ({ $auth, redirect, store }, inject) {
       // TODO 成功時にstoreにtype入れ込む
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログアウトしました'])
-      redirect(logoutInfo.redirecttUrl)
+      redirect(logoutInfo.redirectUrl)
       return response
     } catch (error) {
       // TODO 失敗時にstoreにtype入れ込む


### PR DESCRIPTION
## やったこと
- ログイン前のリダイレクト処理（スタッフ一覧・事業所登録画面は、ログインしないと画面にアクセスできない）
- 事業所詳細が表示できない不具合修正
- 事業所登録画面完成
  - officesテーブルに関する情報の入力フォーム・バリデーション
  - 5枚までの事業所画像アップロード
- 事業所詳細画面で事業所の画像を表示
- ケアマネログイン後に事業所登録画面に遷移
- すでに事業所が登録されていれば、**事業所はすでに登録されています**エラーメッセージ表示
## やらないこと

- ログイン後に、事業所が存在すれば登録画面でなく違う画面にアクセスする設定（来週以降対応予定）

## できるようになること（ユーザ目線）

- ケアマネが事業所を登録できるようになる
- 事業所詳細画面で事業所の画像データを見れる

## できなくなること（ユーザ目線）

- なし

### 確認書類
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

### API 側
- こちらのAPIプルリクの**API側**まで終わらせること
https://github.com/koki-takishita/home-care-navi-api/pull/63
- fetch and checkout

```ruby
git fetch && git checkout origin/feature/office_create
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/office_new
```
### 動作確認　Loom 手順
- 事業所登録画面で事業所登録をする
http://localhost:8000/specialists/office/new
- 事業所詳細画面で、登録した画像をボタンを押してスライドするか確認する（PC・スマホ）
- 画像を選択して、クリックした画像が表示されるか確認する
[事業所登録　手順動画](https://www.loom.com/share/4835717b0a474d6f945f59730782d48f)
[事業所詳細　手順動画](https://www.loom.com/share/9241dd97a74e4f5199480bd831d8783f)

- サンプル画像
[城](https://user-images.githubusercontent.com/34031637/173369453-9508c31d-f2e4-4aea-88b7-276a93181c89.jpg)
[オフィス](https://user-images.githubusercontent.com/34031637/173369998-98a6d1f8-a050-4e75-a6d9-43022cab312a.jpg)
[病院](https://user-images.githubusercontent.com/34031637/173370215-b68fd4e7-2a2b-4d4b-9503-505f0405df79.jpg)
[アパート](https://user-images.githubusercontent.com/34031637/173370324-e5b60910-c20b-40fd-a32d-48db845f8b8e.jpg)
[島](https://user-images.githubusercontent.com/34031637/173370387-10cec341-c61a-41ce-b1e5-117cdcb36e45.png)

## シナリオテスト
以下シナリオテストを、ログイン時と非ログイン時で行う

⑱【ケアマネ】⑯から事業所の登録
事業所詳細表示
２１．16からケアマネがスタッフ登録
２２．16からケアマネがスタッフ編集
２２．16からケアマネがスタッフ削除
## その他
- 事業所詳細画面で、XDに合わせて、事業所画像選択時にオレンジの枠線が出るようにしました。
![image](https://user-images.githubusercontent.com/34031637/173322699-588c2b9b-2af8-4810-b681-a8aa3ca1a204.png)
