### PR TITLE
WEB予約画面・確認画面作成

### DIFF
--- a/pages/offices/_id/appointments/confirm.vue
+++ b/pages/offices/_id/appointments/confirm.vue
@@ -1,14 +1,132 @@
 <template>
-  <v-card>
-    <div>確認画面</div>
-    <p class="mb-0 text-center">
-      <NuxtLink to="." class="text-overline text-decoration-none"
-        >もどる</NuxtLink
+  <div>
+    <p class="mb-0 text-left link-width mx-auto">
+      <NuxtLink
+        to="."
+        class="text-overline text-decoration-none link-color sm-under-no"
+        >＜ {{ office.name }}にもどる</NuxtLink
       >
     </p>
-  </v-card>
+    <v-card class="mx-auto mb-2 p-0" width="750">
+      <v-col><h3>WEB予約</h3></v-col>
+      <v-col class="pb-1">
+        <label class="font-color-gray font-weight-black text-caption"
+          >事業所名</label
+        >
+        <div class="mt-2">{{ office.name }}</div>
+      </v-col>
+      <v-col>
+        <label class="font-color-gray font-weight-black text-caption"
+          >面談希望日時</label
+        ><br />
+        <!-- eslint-disable-next -->
+        <div class="d-flex mt-2">
+          <div>{{ meet_date }}</div>
+          <div class="ml-3">{{ meet_time }}</div>
+        </div>
+      </v-col>
+      <v-col>
+        <label class="font-color-gray font-weight-black text-caption"
+          >利用者のお名前</label
+        ><br />
+        <div class="mt-2">{{ name }}</div>
+      </v-col>
+      <v-col class="">
+        <label class="font-color-gray font-weight-black text-caption"
+          >利用者の年齢</label
+        ><br />
+        <div class="mt-2">{{ age }}</div>
+      </v-col>
+      <v-col>
+        <label class="font-color-gray font-weight-black text-caption"
+          >連絡先電話番号</label
+        ><br />
+        <div class="mt-2">{{ phone_number }}</div>
+      </v-col>
+      <v-col>
+        <label class="font-color-gray font-weight-black text-caption"
+          >お困りごと</label
+        ><br />
+        <div class="mt-2">{{ comment }}</div>
+      </v-col>
+      <v-col>
+        <v-btn x-large block depressed color="error">
+          この内容で予約する
+        </v-btn>
+      </v-col>
+    </v-card>
+  </div>
 </template>
 
 <script>
-export default {}
+export default {
+  layout: 'application',
+  middleware: 'authentication',
+  data() {
+    return {
+      office_id: this.$route.params.id,
+      office: [],
+      meet_date: '',
+      meet_time: '',
+      name: '',
+      age: '',
+      phone_number: '',
+      comment: '',
+    }
+  },
+  mounted() {
+    const meetDate = localStorage.getItem('appointments.meet_date')
+    const meetTime = localStorage.getItem('appointments.meet_time')
+    const name = localStorage.getItem('appointments.name')
+    const age = localStorage.getItem('appointments.age')
+    const phoneNumber = localStorage.getItem('appointments.phone_number')
+    const comment = localStorage.getItem('appointments.comment')
+    this.getOffice()
+    if (
+      meetDate != null &&
+      meetTime != null &&
+      name != null &&
+      age != null &&
+      phoneNumber != null &&
+      comment != null
+    ) {
+      this.meet_date = localStorage.getItem('appointments.meet_date')
+      this.meet_time = localStorage.getItem('appointments.meet_time')
+      this.name = localStorage.getItem('appointments.name')
+      this.age = localStorage.getItem('appointments.age')
+      this.phone_number = localStorage.getItem('appointments.phone_number')
+      this.comment = localStorage.getItem('appointments.comment')
+    }
+  },
+  methods: {
+    async getOffice() {
+      try {
+        const response = await this.$axios.$get(`offices/${this.office_id}`)
+        this.office = response
+      } catch (error) {
+        return error
+      }
+    },
+  },
+}
 </script>
+<style scoped>
+.link-color {
+  color: #e44343;
+}
+
+.font-color-gray {
+  color: #6d7570;
+}
+
+.link-width {
+  width: 750px;
+}
+
+@media screen and (max-width: 959px) {
+  /* sm以下で表示しない */
+  .sm-under-no {
+    display: none;
+  }
+}
+</style>

--- a/pages/offices/_id/appointments/confirm.vue
+++ b/pages/offices/_id/appointments/confirm.vue
@@ -1,0 +1,14 @@
+<template>
+  <v-card>
+    <div>確認画面</div>
+    <p class="mb-0 text-center">
+      <NuxtLink to="." class="text-overline text-decoration-none"
+        >もどる</NuxtLink
+      >
+    </p>
+  </v-card>
+</template>
+
+<script>
+export default {}
+</script>

--- a/pages/offices/_id/appointments/confirm.vue
+++ b/pages/offices/_id/appointments/confirm.vue
@@ -53,6 +53,11 @@
         <v-btn x-large block depressed color="error">
           この内容で予約する
         </v-btn>
+        <p class="mb-0 text-center">
+          <NuxtLink to="." class="text-overline text-decoration-none link-color"
+            >もどる</NuxtLink
+          >
+        </p>
       </v-col>
     </v-card>
   </div>

--- a/pages/offices/_id/appointments/index.vue
+++ b/pages/offices/_id/appointments/index.vue
@@ -1,0 +1,314 @@
+<template>
+  <div>
+    <p class="mb-0 text-left link-width mx-auto">
+      <NuxtLink
+        to="."
+        class="text-overline text-decoration-none link-color sm-under-no"
+        >＜ {{ office.name }}にもどる</NuxtLink
+      >
+    </p>
+    <v-card class="mx-auto mb-2 p-0" width="750">
+      <v-col cols="12"><h3>WEB予約</h3></v-col>
+      <v-col cols="12" class="pb-1">
+        <label class="font-color-gray font-weight-black text-caption"
+          >事業所名</label
+        >
+        <div class="mt-2">{{ office.name }}</div>
+      </v-col>
+      <v-form v-model="valid">
+        <v-col cols="12">
+          <label class="font-color-gray font-weight-black text-caption"
+            >面談希望日時</label
+          >
+        </v-col>
+        <div v-show="isShow" class="ml-3 error-text">
+          明日以降の日付を選択してください
+        </div>
+        <v-row>
+          <v-col cols="5" class="ml-3">
+            <v-menu
+              ref="menu"
+              v-model="menu"
+              :close-on-content-click="false"
+              :return-value.sync="meet_date"
+              transition="scale-transition"
+              offset-y
+              min-width="auto"
+            >
+              <template #activator="{ on, attrs }">
+                <v-text-field
+                  v-model="meet_date"
+                  :rules="[formValidates.required, formValidates.dateCheck]"
+                  prepend-icon="mdi-calendar"
+                  readonly
+                  v-bind="attrs"
+                  v-on="on"
+                ></v-text-field>
+              </template>
+              <v-date-picker
+                v-model="meet_date"
+                locale="jp-ja"
+                :day-format="(meet_date) => new Date(meet_date).getDate()"
+                no-title
+                scrollable
+              >
+                <v-spacer></v-spacer>
+                <v-btn text color="primary" @click="menu = false">
+                  Cancel
+                </v-btn>
+                <v-btn text color="primary" @click="$refs.menu.save(meet_date)">
+                  OK
+                </v-btn>
+              </v-date-picker>
+            </v-menu>
+          </v-col>
+          <v-col cols="6">
+            <label class="font-color-gray font-weight-black text-caption">
+              <v-select
+                v-model="meet_time"
+                :items="timeItems"
+                :rules="[formValidates.required]"
+                class="mt-2 font-weight-regular"
+                outlined
+              ></v-select>
+            </label>
+          </v-col>
+        </v-row>
+        <v-col cols="12" class="pt-0 pb-0">
+          <label class="font-color-gray font-weight-black text-caption"
+            >利用者のお名前
+            <v-text-field
+              v-model="name"
+              class="mt-2 font-weight-regular"
+              :rules="[formValidates.required, formValidates.nameCountCheck]"
+              placeholder="田中 太郎"
+              outlined
+              dense
+              height="44"
+          /></label>
+        </v-col>
+        <v-col cols="5" class="pt-0 pb-0">
+          <label class="font-color-gray font-weight-black text-caption"
+            >利用者の年齢
+            <v-select
+              v-model="age"
+              :items="ageItems"
+              :rules="[formValidates.required]"
+              class="mt-2 font-weight-regular"
+              outlined
+            ></v-select>
+          </label>
+        </v-col>
+        <v-col cols="12" class="pt-0">
+          <label class="font-color-gray font-weight-black text-caption"
+            >連絡先電話番号
+            <v-text-field
+              v-model="phone_number"
+              :rules="[formValidates.required, formValidates.phoneNumber]"
+              class="mt-2 font-weight-regular"
+              placeholder="080-1234-5678"
+              outlined
+              dense
+              height="44"
+          /></label>
+          <label class="font-color-gray font-weight-black text-caption"
+            >お困りごと
+            <v-textarea
+              v-model="comment"
+              :rules="[formValidates.required]"
+              class="mt-2 font-weight-regular"
+              height="150"
+              outlined
+              dense
+            >
+            </v-textarea
+          ></label>
+        </v-col>
+      </v-form>
+      <v-col cols="12" class="pt-0">
+        <v-btn
+          :disabled="!valid"
+          x-large
+          block
+          depressed
+          color="error"
+          @click="sendConfirmPage"
+        >
+          確認へ進む
+        </v-btn>
+      </v-col>
+    </v-card>
+  </div>
+</template>
+
+<script>
+export default {
+  layout: 'application',
+  data() {
+    return {
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        dateCheck: () => {
+          // 現在日時(形式:: Tue Jun 14 2022 22:03:16 GMT+0900 (日本標準時))
+          this.today = new Date()
+          this.currentYear = this.today.getFullYear()
+          this.currentMonth = `0${this.today.getMonth() + 1}`.slice(-2)
+          this.currentDay = this.today.getDate()
+          // todayから年月日を取得したものを組み合わせる(20220101)
+          this.todaySum = this.currentYear + this.currentMonth + this.currentDay
+          // カレンダーから取得した値を、年月日を個別に取得する(2022-01-01)
+          this.yearSlice = `${this.meet_date.slice(0, 4)}`
+          this.monthSlice = `${this.meet_date.slice(5, 7)}`
+          this.daySlice = `${this.meet_date.slice(8, 10)}`
+          // meet_dateをハイフン抜きにしたものを組み合わせる(2022-01-01から20220101)
+          this.dateSliceSum = this.yearSlice + this.monthSlice + this.daySlice
+          // 選択された日付が今日以前の日付なら、バリデーションかける
+          if (Number(this.dateSliceSum) - Number(this.todaySum) < 1) {
+            this.isShow = true
+            return false
+            // 選択された日付が明日以降の日付なら、バリデーション突破
+          } else {
+            this.isShow = false
+            return true
+          }
+        },
+        nameCountCheck: (value) =>
+          value.length <= 31 || '30文字以下で入力してください',
+        phoneNumber: (value) => {
+          const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
+          return format.test(value) || '正しい電話番号ではありません'
+        },
+      },
+      // 入力フォームに関するもの
+      office_id: this.$route.params.id,
+      name: '',
+      meet_date: new Date(Date.now() - new Date().getTimezoneOffset() * 60000)
+        .toISOString()
+        .substr(0, 10),
+      meet_time: '',
+      age: '',
+      phone_number: '',
+      comment: '',
+      called_status: 0,
+      valid: false,
+      isShow: false,
+      menu: false,
+      // 計算や値の取得に使用する
+      startTime: -2,
+      endTime: 0,
+      currentYear: 0,
+      currentMonth: 0,
+      currentDay: 0,
+      currentTime: new Date().getTime(),
+      today: 0,
+      todaySum: 0,
+      yearSlice: '',
+      monthSlice: '',
+      dateSliceSum: '',
+      daySlice: '',
+      office: [],
+      timeItems: [],
+      ageItems: [],
+    }
+  },
+  mounted() {
+    this.addItems()
+    this.getOffice()
+    // もし、ローカルストレージに保存した値が有効期限を過ぎていたら、すべて削除
+    if (
+      Math.floor(this.currentTime / 1000) >=
+      parseInt(localStorage.getItem('appointments.expiry'))
+    ) {
+      localStorage.removeItem('appointments.meet_date')
+      localStorage.removeItem('appointments.meet_time')
+      localStorage.removeItem('appointments.name')
+      localStorage.removeItem('appointments.age')
+      localStorage.removeItem('appointments.phone_number')
+      localStorage.removeItem('appointments.comment')
+      localStorage.removeItem('appointments.expiry')
+    }
+    const meetDate = localStorage.getItem('appointments.meet_date')
+    const meetTime = localStorage.getItem('appointments.meet_time')
+    const name = localStorage.getItem('appointments.name')
+    const age = localStorage.getItem('appointments.age')
+    const phoneNumber = localStorage.getItem('appointments.phone_number')
+    const comment = localStorage.getItem('appointments.comment')
+    if (
+      meetDate != null &&
+      meetTime != null &&
+      name != null &&
+      age != null &&
+      phoneNumber != null &&
+      comment != null
+    ) {
+      this.meet_date = localStorage.getItem('appointments.meet_date')
+      this.meet_time = localStorage.getItem('appointments.meet_time')
+      this.name = localStorage.getItem('appointments.name')
+      this.age = localStorage.getItem('appointments.age')
+      this.phone_number = localStorage.getItem('appointments.phone_number')
+      this.comment = localStorage.getItem('appointments.comment')
+    }
+  },
+  methods: {
+    addItems() {
+      // 年齢のリストを配列にプッシュする
+      for (let i = 60; i <= 120; i++) {
+        this.ageItems.push(`${i}歳`)
+      }
+      // 面談希望時間を配列にプッシュする
+      for (let i = 0; i <= 11; i++) {
+        this.startTime += 2
+        this.endTime += 2
+        this.timeItems.push(`${this.startTime}:00〜${this.endTime}:00`)
+      }
+    },
+    async getOffice() {
+      try {
+        const response = await this.$axios.$get(`offices/${this.office_id}`)
+        this.office = response
+      } catch (error) {
+        return error
+      }
+    },
+    sendConfirmPage() {
+      // 現在のUNIX時間から、有効期限を設定する(UNIX時間は単位が秒なので、秒数を足す)
+      // https://keisan.casio.jp/exec/system/1526004418
+      const expiry = Math.floor(this.currentTime / 1000) + 180
+      localStorage.setItem('appointments.meet_date', this.meet_date)
+      localStorage.setItem('appointments.meet_time', this.meet_time)
+      localStorage.setItem('appointments.name', this.name)
+      localStorage.setItem('appointments.age', this.age)
+      localStorage.setItem('appointments.phone_number', this.phone_number)
+      localStorage.setItem('appointments.comment', this.comment)
+      localStorage.setItem('appointments.expiry', expiry)
+
+      this.$router.push(`/offices/${this.office_id}/appointments/confirm`)
+    },
+  },
+}
+</script>
+<style scoped>
+.link-color {
+  color: #ee7b1a;
+}
+
+.font-color-gray {
+  color: #6d7570;
+}
+
+.link-width {
+  width: 750px;
+}
+
+.error-text {
+  color: #fc5454;
+  font-size: 13px;
+}
+
+@media screen and (max-width: 959px) {
+  /* sm以下で表示しない */
+  .sm-under-no {
+    display: none;
+  }
+}
+</style>

--- a/pages/offices/_id/appointments/index.vue
+++ b/pages/offices/_id/appointments/index.vue
@@ -291,7 +291,7 @@ export default {
 </script>
 <style scoped>
 .link-color {
-  color: #ee7b1a;
+  color: #e44343;
 }
 
 .font-color-gray {

--- a/pages/offices/_id/appointments/index.vue
+++ b/pages/offices/_id/appointments/index.vue
@@ -144,6 +144,7 @@
 <script>
 export default {
   layout: 'application',
+  middleware: 'authentication',
   data() {
     return {
       formValidates: {
@@ -273,7 +274,7 @@ export default {
     sendConfirmPage() {
       // 現在のUNIX時間から、有効期限を設定する(UNIX時間は単位が秒なので、秒数を足す)
       // https://keisan.casio.jp/exec/system/1526004418
-      const expiry = Math.floor(this.currentTime / 1000) + 180
+      const expiry = Math.floor(this.currentTime / 1000) + 60
       localStorage.setItem('appointments.meet_date', this.meet_date)
       localStorage.setItem('appointments.meet_time', this.meet_time)
       localStorage.setItem('appointments.name', this.name)

--- a/pages/offices/_id/appointments/index.vue
+++ b/pages/offices/_id/appointments/index.vue
@@ -272,6 +272,7 @@ export default {
       }
     },
     sendConfirmPage() {
+      this.currentTime = new Date().getTime()
       // 現在のUNIX時間から、有効期限を設定する(UNIX時間は単位が秒なので、秒数を足す)
       // https://keisan.casio.jp/exec/system/1526004418
       const expiry = Math.floor(this.currentTime / 1000) + 180

--- a/pages/offices/_id/appointments/index.vue
+++ b/pages/offices/_id/appointments/index.vue
@@ -274,7 +274,7 @@ export default {
     sendConfirmPage() {
       // 現在のUNIX時間から、有効期限を設定する(UNIX時間は単位が秒なので、秒数を足す)
       // https://keisan.casio.jp/exec/system/1526004418
-      const expiry = Math.floor(this.currentTime / 1000) + 60
+      const expiry = Math.floor(this.currentTime / 1000) + 180
       localStorage.setItem('appointments.meet_date', this.meet_date)
       localStorage.setItem('appointments.meet_time', this.meet_time)
       localStorage.setItem('appointments.name', this.name)

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -228,7 +228,15 @@
               </div>
             </v-col>
             <v-col cols="12">
-              <v-btn x-large block depressed color="error"> WEB予約する </v-btn>
+              <v-btn
+                x-large
+                block
+                depressed
+                color="error"
+                @click="goAppointmentsPage"
+              >
+                WEB予約する
+              </v-btn>
             </v-col>
             <v-col class="py-1" cols="12">
               <div class="holiday-pc">営業日</div>
@@ -392,6 +400,9 @@ export default {
       } else {
         this.active++
       }
+    },
+    goAppointmentsPage() {
+      this.$router.push(`/offices/${this.office_id}/appointments`)
     },
   },
 }


### PR DESCRIPTION
## やったこと

- WEB予約画面作成（ログインしてないとアクセスできない）
- 「確認へ進む」ボタンを押したときに、ローカルストレージに入力フォームの値を保存
- ローカルストレージに保存したときに有効期限を設定（3分）
- WEB予約確認画面を作成（ログインしてないとアクセスできない）
- 事業所詳細画面の「WEB予約するボタン」からWEB予約画面に遷移

## やらないこと

- 面談希望日時に曜日をつけること（要相談）
- 確認画面で「予約する」ボタンの実装（今日か明日実装予定）

## できるようになること（ユーザ目線）

- 事業所詳細画面からWEB予約画面に遷移することができる
- 予約した内容を確認できる

## できなくなること（ユーザ目線）

- なし

## 確認書類

[画面一覧書 url](https://docs.google.com/spreadsheets/d/1zBUODbQx18IKoKiNmmvuOu6PvCYvTNH5-YTG1JIAcOQ/edit#gid=334611837)
[XD WEB予約画面-PC](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/3bf54144-413f-455a-866b-99a1479b8e62)
[XD WEB予約画面-SP](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/2c620e5b-f45c-4db9-87eb-c35a5b321931)
[XD WEB予約内容確認画面 PC](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/4e5e4e48-7947-4389-b9dd-dc6c857d5b22)
[XD WEB予約内容確認画面 SP](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/f49098cd-b29b-4e27-8fa6-9e080db66240)
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointment
```

## 動作確認  loom手順

loom動画参照
http://localhost:8000/offices/事業所のID
http://localhost:8000/offices/事業所のID/appointments
[手順動画](https://www.loom.com/share/0f5c1b60bd474e2fa58cc95b527112ed)

**追記**
予約内容確認画面作成しました。
![image](https://user-images.githubusercontent.com/34031637/173727115-055ce897-afcd-4189-a4a4-4d285f11a9dd.png)

## シナリオテスト
以下シナリオテストを、ログイン時と非ログイン時で行う

⑱【ケアマネ】⑯から事業所の登録
9 4から事業所詳細画面に行き予約
8 3から事業所を選択し予約
２１．16からケアマネがスタッフ登録
２２．16からケアマネがスタッフ編集
２２．16からケアマネがスタッフ削除
## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- 動作確認時に、レビューの時間短縮のため、一時的にローカルストレージの有効期限を短くしてもよい
pages/offices/_id/appointments/index.vue
```javascript
<script>
(略)
sendConfirmPage() {
      // +180は、現在時刻から180秒後が有効期限という意味なので、好きな秒数に設定する
      const expiry = Math.floor(this.currentTime / 1000) + 180
      this.$router.push(`/offices/${this.office_id}/appointments/confirm`)
    },
</script>
```