### PR TITLE
ログイン後ヘッダーレイアウト

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -258,19 +258,36 @@
         </v-card>
         <v-list v-if="$auth.loggedIn" nav dense class="pa-0">
           <v-list-item-group v-model="group">
-            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
-              <v-list-item-title>
-                <NuxtLink
-                  to="#"
-                  class="text-decoration-none text-body-2 navi-style"
-                  >事業所情報編集</NuxtLink
-                >
-              </v-list-item-title>
-              <v-list-item-icon class="ma-0 mt-2">
-                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
-              </v-list-item-icon>
-            </v-list-item>
-            <v-divider color="#D9DEDE"></v-divider>
+            <div v-if="office === true">
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="#"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >事業所情報編集</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+            </div>
+            <div v-else>
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="#"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >事業所登録</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+            </div>
             <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
               <v-list-item-title>
                 <NuxtLink
@@ -457,7 +474,6 @@ export default {
     },
   },
   mounted() {
-    console.log('マウンテッド')
     if (typeof window.localStorage.office_data !== 'undefined') {
       this.office = true
     } else {

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -29,36 +29,91 @@
               <div class="d-flex justify-end">
                 <div v-if="$auth.loggedIn">
                   <div class="mr-8 d-flex align-center">
-                    <NuxtLink
-                      to="#"
-                      class="header-style text-overline mr-5 text-decoration-none"
-                      >事業所情報編集</NuxtLink
-                    >
-                    <NuxtLink
-                      to="#"
-                      class="header-style text-overline mr-5 text-decoration-none"
-                      >スタッフ情報</NuxtLink
-                    >
-                    <NuxtLink
-                      to="#"
-                      class="header-style text-overline mr-5 text-decoration-none"
-                      >お礼一覧</NuxtLink
-                    >
-                    <NuxtLink
-                      to="#"
-                      class="header-style text-overline text-decoration-none mr-5"
-                      >予約状況確認</NuxtLink
-                    >
-                    <NuxtLink
-                      to="#"
-                      class="header-style text-overline text-decoration-none mr-5"
-                      >利用者情報管理</NuxtLink
-                    >
-                    <NuxtLink
-                      to="#"
-                      class="header-style text-overline text-decoration-none mr-5"
-                      >登録情報</NuxtLink
-                    >
+                    <div class="text-center mr-7">
+                      <v-menu offset-y>
+                        <template #activator="{ on, attrs }">
+                          <v-btn
+                            text
+                            color="#808080"
+                            dark
+                            v-bind="attrs"
+                            v-on="on"
+                          >
+                            ケアマネメニュー
+                            <v-icon>mdi-menu-down</v-icon>
+                          </v-btn>
+                        </template>
+                        <v-list>
+                          <div v-if="office === true">
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="#"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >事業所情報編集</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                          </div>
+                          <div v-else>
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="#"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >事業所登録</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                          </div>
+                          <v-list-item>
+                            <v-list-item-title>
+                              <NuxtLink
+                                to="#"
+                                class="header-style text-overline text-decoration-none mr-5"
+                                >スタッフ情報</NuxtLink
+                              ></v-list-item-title
+                            >
+                          </v-list-item>
+                          <v-list-item>
+                            <v-list-item-title>
+                              <NuxtLink
+                                to="#"
+                                class="header-style text-overline text-decoration-none mr-5"
+                                >お礼一覧</NuxtLink
+                              ></v-list-item-title
+                            >
+                          </v-list-item>
+                          <v-list-item>
+                            <v-list-item-title>
+                              <NuxtLink
+                                to="#"
+                                class="header-style text-overline text-decoration-none mr-5"
+                                >予約状況確認</NuxtLink
+                              ></v-list-item-title
+                            >
+                          </v-list-item>
+                          <v-list-item>
+                            <v-list-item-title>
+                              <NuxtLink
+                                to="#"
+                                class="header-style text-overline text-decoration-none mr-5"
+                                >利用者情報管理</NuxtLink
+                              ></v-list-item-title
+                            >
+                          </v-list-item>
+                          <v-list-item>
+                            <v-list-item-title>
+                              <NuxtLink
+                                to="#"
+                                class="header-style text-overline text-decoration-none mr-5"
+                                >登録情報</NuxtLink
+                              ></v-list-item-title
+                            >
+                          </v-list-item>
+                        </v-list>
+                      </v-menu>
+                    </div>
                     <div class="red--text line-style">
                       <v-btn
                         :width="120"
@@ -389,6 +444,24 @@ export default {
       drawer: false,
       group: null,
       tile: false,
+      office: '',
+    }
+  },
+  watch: {
+    $route() {
+      if (typeof window.localStorage.office_data !== 'undefined') {
+        this.office = true
+      } else {
+        this.office = false
+      }
+    },
+  },
+  mounted() {
+    console.log('マウンテッド')
+    if (typeof window.localStorage.office_data !== 'undefined') {
+      this.office = true
+    } else {
+      this.office = false
     }
   },
 

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -39,7 +39,7 @@
                             v-bind="attrs"
                             v-on="on"
                           >
-                            ケアマネメニュー
+                            メニュー
                             <v-icon>mdi-menu-down</v-icon>
                           </v-btn>
                         </template>

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -312,6 +312,7 @@ export default {
         await this.$axios.$post(`specialists/offices`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
+        localStorage.setItem('office_data', 'true')
       } catch (error) {
         return error
       }

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -58,7 +58,6 @@ const error500 = function (store) {
 const setAuthInfoToLocalStorage = function (response) {
   // TODO メソッドの名前が適切でないかも、ログイン処理が成功したらみたいなのがほしい
   const headers = response.headers
-  console.log(headers.office_data)
   if (headers.office_data) {
     localStorage.setItem('office_data', headers.office_data)
   }

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -58,6 +58,10 @@ const error500 = function (store) {
 const setAuthInfoToLocalStorage = function (response) {
   // TODO メソッドの名前が適切でないかも、ログイン処理が成功したらみたいなのがほしい
   const headers = response.headers
+  console.log(headers.office_data)
+  if (headers.office_data) {
+    localStorage.setItem('office_data', headers.office_data)
+  }
   if (
     headers.client &&
     headers.uid &&

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -23,5 +23,6 @@ export default function ({ $auth, redirect, store }, inject) {
     localStorage.removeItem('expiry')
     localStorage.removeItem('client')
     localStorage.removeItem('uid')
+    localStorage.removeItem('office_data')
   }
 }


### PR DESCRIPTION
## やったこと

### ケアマネログインのヘッダー編集
1.ケアマネージャーログイン後のヘッダーレイアウト
2.ログイン時事業所を持っていれば、事業所編集を表示。持っていなければ、事業所登録を表示

## やらないこと

* ヘッダーのリンクの遷移先（各担当の方設定お願いします）

## できるようになること（ユーザ目線）

* レイアウトがすっきりしてみやすくなる
* 事業所を登録してないときは登録が表示されて、登録してる時は編集が表示される

## できなくなること（ユーザ目線）

* 特になし

## 動作確認

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/specialists_login
```

### フロント 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/specialist-header
```

## 事業所持っていないケアマネの確認手順

1,rails db seedを実行
2,ケアマネログインページ `http://localhost:8000/specialists/login`からログイン
```
メールアドレス　specialist@example.com
パスワード　password
```
3.メニューを開き『事業所登録』があることを確認

## 事業所持っていないケアマネの確認手順
4.事業所を登録
5.ログアウト
6.再度ログイン
7.メニューを開く
8.事業所を登録したので、メニューを開く事業所編集になっている

[手順動画](https://www.loom.com/share/c850f23300cc4898b17784a729794ed4)

## その他

フロントとAPI合わせて確認お願いします
