### PR TITLE
WEB予約完了画面　登録リクエスト送信など

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ git fetch && git checkout origin/feature/<ここを変える>
 
 # **必要なかったら消すこと**
 
-### Front 側 git
+### Front 側
 
 - fetch and checkout
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,46 +1,18 @@
-## プルリクルール守ってね
-
-[プルリクルール](https://docs.google.com/spreadsheets/d/1XXQGmsRkmIlOpTE6KN6sx6Uya4u_lGKgscMaRdBZDzA/edit#gid=0)
-
 ## やったこと
 
 - このプルリクで何をしたのか？
-
-1. 〇〇機能実装
-2. 〇〇機能実装
 
 ## やらないこと
 
 - このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
 
-1. PC のレイアウトのみ
-2. 〇〇は対応しない
-
 ## できるようになること（ユーザ目線）
 
 - 何ができるようになるのか？（あれば。無いなら「無し」で OK）
 
-1. ログインが出来るようになる
-2. 〇〇が出来るようになる
-
 ## できなくなること（ユーザ目線）
 
 - 何ができなくなるのか？（あれば。無いなら「無し」で OK）
-
-1. ログアウトができなくなる
-2. 〇〇ができなくなる
-
-## 動作確認
-
-### 確認書類
-
-# **必要なかったら消すこと**
-
-[画面図 url は該当のやつに変えること](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)
-[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)
-[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)
-[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)
-[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)
 
 # **必要なかったら消すこと**
 
@@ -72,21 +44,38 @@ git fetch && git checkout origin/feature/<ここを変える>
 docker-compose build
 ```
 
-- コンテナ入る
-
-```ruby
-docker-compose exec web bash
-```
-
 - コンテナリスタート
 
 ```ruby
 docker-compose restart
 ```
 
-### Loom 手順
+- コンテナ入る
 
-[手順動画](urlが入る)
+```ruby
+docker-compose exec web bash
+```
+
+- コンソール入る
+
+```ruby
+rails c
+```
+
+### 動作確認 Loom 手順
+
+- 〇〇をする
+  [手順動画](urlが入る)
+
+### 確認書類
+
+# **必要なかったら消すこと**
+
+[画面図 url は該当のやつに変えること](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)
+[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)
+[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)
+[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)
+[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)
 
 ## その他
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ git fetch && git checkout origin/feature/<ここを変える>
 
 # **必要なかったら消すこと**
 
-### Front 側
+### Front 側 git
 
 - fetch and checkout
 

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -350,6 +350,22 @@ export default {
       drawer: false,
       group: null,
       tile: false,
+      currentTime: new Date().getTime(),
+    }
+  },
+  mounted() {
+    // もし、ローカルストレージに保存した値が有効期限を過ぎていたら、すべて削除
+    if (
+      Math.floor(this.currentTime / 1000) >=
+      parseInt(localStorage.getItem('appointments.expiry'))
+    ) {
+      localStorage.removeItem('appointments.meet_date')
+      localStorage.removeItem('appointments.meet_time')
+      localStorage.removeItem('appointments.name')
+      localStorage.removeItem('appointments.age')
+      localStorage.removeItem('appointments.phone_number')
+      localStorage.removeItem('appointments.comment')
+      localStorage.removeItem('appointments.expiry')
     }
   },
   methods: {

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -59,7 +59,7 @@
                             <v-list-item>
                               <v-list-item-title>
                                 <NuxtLink
-                                  to="#"
+                                  to="/specialists/office/new"
                                   class="header-style text-overline text-decoration-none mr-5"
                                   >事業所登録</NuxtLink
                                 ></v-list-item-title
@@ -69,7 +69,7 @@
                           <v-list-item>
                             <v-list-item-title>
                               <NuxtLink
-                                to="#"
+                                to="/specialists/office/1/staffs"
                                 class="header-style text-overline text-decoration-none mr-5"
                                 >スタッフ情報</NuxtLink
                               ></v-list-item-title
@@ -277,7 +277,7 @@
               <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
                 <v-list-item-title>
                   <NuxtLink
-                    to="#"
+                    to="/specialists/office/new"
                     class="text-decoration-none text-body-2 navi-style"
                     >事業所登録</NuxtLink
                   >
@@ -291,7 +291,7 @@
             <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
               <v-list-item-title>
                 <NuxtLink
-                  to="#"
+                  to="/specialists/office/1/staffs"
                   class="text-decoration-none text-body-2 navi-style"
                   >スタッフ情報</NuxtLink
                 >
@@ -479,9 +479,6 @@ export default {
       this.office = true
     } else {
       this.office = false
-    }
-    if (localStorage.getItem('myOfficeId') !== null) {
-      this.office_id = localStorage.getItem('myOfficeId')
     }
   },
 

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -48,7 +48,7 @@
                             <v-list-item>
                               <v-list-item-title>
                                 <NuxtLink
-                                  to="#"
+                                  to="/specialists/office/1/edit"
                                   class="header-style text-overline text-decoration-none mr-5"
                                   >事業所情報編集</NuxtLink
                                 ></v-list-item-title
@@ -262,7 +262,7 @@
               <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
                 <v-list-item-title>
                   <NuxtLink
-                    to="#"
+                    to="/specialists/office/1/edit"
                     class="text-decoration-none text-body-2 navi-style"
                     >事業所情報編集</NuxtLink
                   >
@@ -462,6 +462,7 @@ export default {
       group: null,
       tile: false,
       office: '',
+      office_id: '',
     }
   },
   watch: {
@@ -478,6 +479,9 @@ export default {
       this.office = true
     } else {
       this.office = false
+    }
+    if (localStorage.getItem('myOfficeId') !== null) {
+      this.office_id = localStorage.getItem('myOfficeId')
     }
   },
 

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -44,18 +44,7 @@
                           </v-btn>
                         </template>
                         <v-list>
-                          <div v-if="office === true">
-                            <v-list-item>
-                              <v-list-item-title>
-                                <NuxtLink
-                                  to="/specialists/office/1/edit"
-                                  class="header-style text-overline text-decoration-none mr-5"
-                                  >事業所情報編集</NuxtLink
-                                ></v-list-item-title
-                              >
-                            </v-list-item>
-                          </div>
-                          <div v-else>
+                          <div v-if="office !== true">
                             <v-list-item>
                               <v-list-item-title>
                                 <NuxtLink
@@ -66,42 +55,53 @@
                               >
                             </v-list-item>
                           </div>
-                          <v-list-item>
-                            <v-list-item-title>
-                              <NuxtLink
-                                to="/specialists/office/1/staffs"
-                                class="header-style text-overline text-decoration-none mr-5"
-                                >スタッフ情報</NuxtLink
-                              ></v-list-item-title
-                            >
-                          </v-list-item>
-                          <v-list-item>
-                            <v-list-item-title>
-                              <NuxtLink
-                                to="#"
-                                class="header-style text-overline text-decoration-none mr-5"
-                                >お礼一覧</NuxtLink
-                              ></v-list-item-title
-                            >
-                          </v-list-item>
-                          <v-list-item>
-                            <v-list-item-title>
-                              <NuxtLink
-                                to="#"
-                                class="header-style text-overline text-decoration-none mr-5"
-                                >予約状況確認</NuxtLink
-                              ></v-list-item-title
-                            >
-                          </v-list-item>
-                          <v-list-item>
-                            <v-list-item-title>
-                              <NuxtLink
-                                to="#"
-                                class="header-style text-overline text-decoration-none mr-5"
-                                >利用者情報管理</NuxtLink
-                              ></v-list-item-title
-                            >
-                          </v-list-item>
+                          <div v-else>
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="/specialists/office/1/edit"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >事業所情報編集</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="/specialists/office/1/staffs"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >スタッフ情報</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="#"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >お礼一覧</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="#"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >予約状況確認</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                            <v-list-item>
+                              <v-list-item-title>
+                                <NuxtLink
+                                  to="#"
+                                  class="header-style text-overline text-decoration-none mr-5"
+                                  >利用者情報管理</NuxtLink
+                                ></v-list-item-title
+                              >
+                            </v-list-item>
+                          </div>
                           <v-list-item>
                             <v-list-item-title>
                               <NuxtLink
@@ -258,22 +258,7 @@
         </v-card>
         <v-list v-if="$auth.loggedIn" nav dense class="pa-0">
           <v-list-item-group v-model="group">
-            <div v-if="office === true">
-              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
-                <v-list-item-title>
-                  <NuxtLink
-                    to="/specialists/office/1/edit"
-                    class="text-decoration-none text-body-2 navi-style"
-                    >事業所情報編集</NuxtLink
-                  >
-                </v-list-item-title>
-                <v-list-item-icon class="ma-0 mt-2">
-                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
-                </v-list-item-icon>
-              </v-list-item>
-              <v-divider color="#D9DEDE"></v-divider>
-            </div>
-            <div v-else>
+            <div v-if="office !== true">
               <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
                 <v-list-item-title>
                   <NuxtLink
@@ -288,58 +273,73 @@
               </v-list-item>
               <v-divider color="#D9DEDE"></v-divider>
             </div>
-            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
-              <v-list-item-title>
-                <NuxtLink
-                  to="/specialists/office/1/staffs"
-                  class="text-decoration-none text-body-2 navi-style"
-                  >スタッフ情報</NuxtLink
-                >
-              </v-list-item-title>
-              <v-list-item-icon class="ma-0 mt-2">
-                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
-              </v-list-item-icon>
-            </v-list-item>
-            <v-divider color="#D9DEDE"></v-divider>
-            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
-              <v-list-item-title>
-                <NuxtLink
-                  to="#"
-                  class="text-decoration-none text-body-2 navi-style"
-                  >お礼一覧</NuxtLink
-                >
-              </v-list-item-title>
-              <v-list-item-icon class="ma-0 mt-2">
-                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
-              </v-list-item-icon>
-            </v-list-item>
-            <v-divider color="#D9DEDE"></v-divider>
-            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
-              <v-list-item-title>
-                <NuxtLink
-                  to="#"
-                  class="text-decoration-none text-body-2 navi-style"
-                  >予約状況確認</NuxtLink
-                >
-              </v-list-item-title>
-              <v-list-item-icon class="ma-0 mt-2">
-                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
-              </v-list-item-icon>
-            </v-list-item>
-            <v-divider color="#D9DEDE"></v-divider>
-            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
-              <v-list-item-title>
-                <NuxtLink
-                  to="#"
-                  class="text-decoration-none text-body-2 navi-style"
-                  >利用者情報管理</NuxtLink
-                >
-              </v-list-item-title>
-              <v-list-item-icon class="ma-0 mt-2">
-                <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
-              </v-list-item-icon>
-            </v-list-item>
-            <v-divider color="#D9DEDE"></v-divider>
+            <div v-else>
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="/specialists/office/1/edit"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >事業所情報編集</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="/specialists/office/1/staffs"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >スタッフ情報</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="#"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >お礼一覧</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="#"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >予約状況確認</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
+                <v-list-item-title>
+                  <NuxtLink
+                    to="#"
+                    class="text-decoration-none text-body-2 navi-style"
+                    >利用者情報管理</NuxtLink
+                  >
+                </v-list-item-title>
+                <v-list-item-icon class="ma-0 mt-2">
+                  <v-icon rage :color="color_g">mdi-chevron-right</v-icon>
+                </v-list-item-icon>
+              </v-list-item>
+              <v-divider color="#D9DEDE"></v-divider>
+            </div>
             <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
               <v-list-item-title>
                 <NuxtLink

--- a/pages/offices/_id/appointments/confirm.vue
+++ b/pages/offices/_id/appointments/confirm.vue
@@ -50,7 +50,7 @@
         <div class="mt-2">{{ comment }}</div>
       </v-col>
       <v-col>
-        <v-btn x-large block depressed color="error">
+        <v-btn x-large block depressed color="error" @click="sendSuccessPage">
           この内容で予約する
         </v-btn>
         <p class="mb-0 text-center">
@@ -108,6 +108,28 @@ export default {
       try {
         const response = await this.$axios.$get(`offices/${this.office_id}`)
         this.office = response
+      } catch (error) {
+        return error
+      }
+    },
+    async sendSuccessPage() {
+      try {
+        const response = await this.$axios.$post(
+          `offices/${this.office_id}/appointments`,
+          {
+            office_id: this.office_id,
+            meet_date: this.meet_date,
+            meet_time: this.meet_time,
+            name: this.name,
+            age: this.age,
+            phone_number: this.phone_number,
+            comment: this.comment,
+            called_status: 0,
+          }
+        )
+        this.$router.push('/users/send')
+        this.$router.push(`/offices/${this.office_id}/appointments/success`)
+        return response
       } catch (error) {
         return error
       }

--- a/pages/offices/_id/appointments/index.vue
+++ b/pages/offices/_id/appointments/index.vue
@@ -200,7 +200,6 @@ export default {
       currentYear: 0,
       currentMonth: 0,
       currentDay: 0,
-      currentTime: new Date().getTime(),
       today: 0,
       todaySum: 0,
       yearSlice: '',
@@ -215,25 +214,14 @@ export default {
   mounted() {
     this.addItems()
     this.getOffice()
-    // もし、ローカルストレージに保存した値が有効期限を過ぎていたら、すべて削除
-    if (
-      Math.floor(this.currentTime / 1000) >=
-      parseInt(localStorage.getItem('appointments.expiry'))
-    ) {
-      localStorage.removeItem('appointments.meet_date')
-      localStorage.removeItem('appointments.meet_time')
-      localStorage.removeItem('appointments.name')
-      localStorage.removeItem('appointments.age')
-      localStorage.removeItem('appointments.phone_number')
-      localStorage.removeItem('appointments.comment')
-      localStorage.removeItem('appointments.expiry')
-    }
+
     const meetDate = localStorage.getItem('appointments.meet_date')
     const meetTime = localStorage.getItem('appointments.meet_time')
     const name = localStorage.getItem('appointments.name')
     const age = localStorage.getItem('appointments.age')
     const phoneNumber = localStorage.getItem('appointments.phone_number')
     const comment = localStorage.getItem('appointments.comment')
+
     if (
       meetDate != null &&
       meetTime != null &&
@@ -266,16 +254,16 @@ export default {
     async getOffice() {
       try {
         const response = await this.$axios.$get(`offices/${this.office_id}`)
-        this.office = response
+        this.office = response.office
       } catch (error) {
         return error
       }
     },
     sendConfirmPage() {
-      this.currentTime = new Date().getTime()
+      const currentTime = new Date().getTime()
       // 現在のUNIX時間から、有効期限を設定する(UNIX時間は単位が秒なので、秒数を足す)
       // https://keisan.casio.jp/exec/system/1526004418
-      const expiry = Math.floor(this.currentTime / 1000) + 180
+      const expiry = Math.floor(currentTime / 1000) + 180
       localStorage.setItem('appointments.meet_date', this.meet_date)
       localStorage.setItem('appointments.meet_time', this.meet_time)
       localStorage.setItem('appointments.name', this.name)

--- a/pages/offices/_id/appointments/success.vue
+++ b/pages/offices/_id/appointments/success.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-card outlined width="750" class="mx-auto mt-10">
+    <v-card-text>
+      <div>
+        <h1 class="text-center mt-8 title-text d-none d-sm-block">
+          Web予約完了
+        </h1>
+      </div>
+      <div>
+        <h1 class="mt-8 title-text d-sm-none">Web予約完了</h1>
+      </div>
+      <div class="text-center mt-12">
+        <p>ご予約が完了しました。<br />事業所からの連絡をお待ちください。</p>
+      </div>
+      <p class="mb-16 text-center">
+        <NuxtLink to=".." class="text-overline text-decoration-none link-color"
+          >事業所のページに戻る</NuxtLink
+        >
+      </p>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  layout: 'application',
+  middleware: 'authentication',
+  data() {
+    return {}
+  },
+}
+</script>
+<style scoped>
+.link-color {
+  color: #e44343;
+}
+</style>

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -70,14 +70,14 @@
               <v-icon>mdi-map-marker</v-icon>
               <div class="my-auto">東京駅 徒歩5分</div>
               <v-icon>mdi-account</v-icon>
-              <div class="my-auto">スタッフ数 {{ office.staffs.length }}人</div>
+              <div class="my-auto">スタッフ数 人</div>
             </div>
           </v-col>
           <v-col class="pt-0" md="12" xs="6">
-            <v-icon large>mdi-phone</v-icon>{{ office.office.phone_number }}
+            <v-icon large>mdi-phone</v-icon>{{ office.phone_number }}
             <div class="flex">
               <div class="fax pr-1">FAX</div>
-              <div class="my-auto">{{ office.office.fax_number }}</div>
+              <div class="my-auto">{{ office.fax_number }}</div>
             </div>
           </v-col>
           <v-col cols="12"
@@ -89,120 +89,18 @@
                 <div class="holiday-sp">営業日</div>
               </v-col>
               <v-col class="pl-0" cols="10">
-                <div>
-                  <table>
-                    <tbody>
-                      <tr>
-                        <th>日</th>
-                        <th>月</th>
-                        <th>火</th>
-                        <th>水</th>
-                        <th>木</th>
-                        <th>金</th>
-                        <th>土</th>
-                      </tr>
-                      <tr>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('sunday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('monday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('tuesday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('wednesday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('thursday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('friday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                        <td class="py-2">
-                          <v-icon
-                            v-if="
-                              office.office.selected_flags.includes('saturday')
-                            "
-                            class="d-flex"
-                            >mdi-close</v-icon
-                          >
-                          <v-icon v-else class="d-flex" color="orange"
-                            >mdi-circle-outline</v-icon
-                          >
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+                <div></div>
               </v-col>
             </v-row>
             <div class="mt-4 md-over-no holiday-detail">
-              {{ office.office.business_day_detail }}
+              {{ office.business_day_detail }}
             </div>
           </v-col>
         </v-card>
         <v-card class="mt-6" outlined tile height="491">
-          <v-col class="office-title" cols="12"
-            >{{ office.office.title }}
-          </v-col>
+          <v-col class="office-title" cols="12">{{ office.title }} </v-col>
           <v-col class="title_detail" cols="12"
-            >{{ office.office.title_detail }}
+            >{{ office.title_detail }}
           </v-col>
         </v-card>
         <v-card class="mt-6" outlined tile height="599">
@@ -215,9 +113,7 @@
       <v-col cols="12" sm="12" md="6">
         <v-card class="sm-under-no sticky" outlined tile>
           <v-row class="mx-auto mt-auto max-width">
-            <v-col class="office-name" cols="10"
-              >{{ office.office.name }}
-            </v-col>
+            <v-col class="office-name" cols="10">{{ office.name }} </v-col>
             <v-col class="pl-0" ols="2">
               <v-btn fab depressed>
                 <v-icon large color="white">mdi-star</v-icon>
@@ -225,26 +121,24 @@
             </v-col>
             <v-col cols="12">
               <div class="office-tel">
-                〒{{ office.office.post_code }}
+                〒{{ office.post_code }}
                 <br />
-                {{ office.office.address }}
+                {{ office.address }}
               </div>
               <div class="mt-3 flex access-and-staff">
                 <v-icon>mdi-map-marker</v-icon>
                 <div class="my-auto">東京駅 徒歩5分</div>
                 <v-icon>mdi-account</v-icon>
-                <div class="my-auto">
-                  スタッフ数 {{ office.staffs.length }}人
-                </div>
+                <div class="my-auto">スタッフ数 人</div>
               </div>
             </v-col>
             <v-col class="pt-0" md="12" xs="6">
               <div>
-                <v-icon large>mdi-phone</v-icon>{{ office.office.phone_number }}
+                <v-icon large>mdi-phone</v-icon>{{ office.phone_number }}
               </div>
               <div class="flex">
                 <div class="fax pr-1">FAX</div>
-                <div class="my-auto">{{ office.office.fax_number }}</div>
+                <div class="my-auto">{{ office.fax_number }}</div>
               </div>
             </v-col>
             <v-col cols="12">
@@ -262,103 +156,9 @@
               <div class="holiday-pc">営業日</div>
             </v-col>
             <v-col>
-              <div>
-                <table>
-                  <tbody>
-                    <tr>
-                      <th>日</th>
-                      <th>月</th>
-                      <th>火</th>
-                      <th>水</th>
-                      <th>木</th>
-                      <th>金</th>
-                      <th>土</th>
-                    </tr>
-                    <tr>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="office.office.selected_flags.includes('sunday')"
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="office.office.selected_flags.includes('monday')"
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="
-                            office.office.selected_flags.includes('tuesday')
-                          "
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="
-                            office.office.selected_flags.includes('wednesday')
-                          "
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="
-                            office.office.selected_flags.includes('thursday')
-                          "
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="office.office.selected_flags.includes('friday')"
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                      <td class="py-2">
-                        <v-icon
-                          v-if="
-                            office.office.selected_flags.includes('saturday')
-                          "
-                          class="d-flex"
-                          >mdi-close</v-icon
-                        >
-                        <v-icon v-else class="d-flex" color="orange"
-                          >mdi-circle-outline</v-icon
-                        >
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
+              <div></div>
               <div class="mt-4 mb-4 holiday-detail">
-                {{ office.office.business_day_detail }}
+                {{ office.business_day_detail }}
               </div>
             </v-col>
           </v-row>

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -3,7 +3,7 @@
     <v-row>
       <v-col cols="12" sm="12" md="6">
         <v-card outlined tile height="338">
-          <v-img :src="office.images[active]" height="338">
+          <v-img v-if="images !== null" :src="images[active]" height="338">
             <v-row>
               <v-col cols="6">
                 <v-btn
@@ -33,21 +33,22 @@
               </v-col>
             </v-row>
           </v-img>
+          <v-img
+            v-else
+            src="https://home-care-navi-bucket.s3.ap-northeast-1.amazonaws.com/no_image.jpeg"
+            height="338"
+          ></v-img>
         </v-card>
         <v-card class="sm-under-no" outlined tile height="85">
-          <div class="thumbnails">
+          <div v-if="images !== null" class="thumbnails">
             <li
-              v-for="index in office.images.length"
+              v-for="index in images.length"
               :key="index"
               :class="{ current: active === index - 1 }"
               class="mx-1"
               @click="current(index)"
             >
-              <v-img
-                :src="office.images[index - 1]"
-                height="50"
-                width="70"
-              ></v-img>
+              <v-img :src="images[index - 1]" height="50" width="70"></v-img>
             </li>
           </div>
         </v-card>
@@ -70,7 +71,7 @@
               <v-icon>mdi-map-marker</v-icon>
               <div class="my-auto">東京駅 徒歩5分</div>
               <v-icon>mdi-account</v-icon>
-              <div class="my-auto">スタッフ数 人</div>
+              <div class="my-auto">スタッフ数 {{ staffs.length }}人</div>
             </div>
           </v-col>
           <v-col class="pt-0" md="12" xs="6">
@@ -89,7 +90,93 @@
                 <div class="holiday-sp">営業日</div>
               </v-col>
               <v-col class="pl-0" cols="10">
-                <div></div>
+                <div>
+                  <table>
+                    <tbody>
+                      <tr>
+                        <th>日</th>
+                        <th>月</th>
+                        <th>火</th>
+                        <th>水</th>
+                        <th>木</th>
+                        <th>金</th>
+                        <th>土</th>
+                      </tr>
+                      <tr>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('sunday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('monday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('tuesday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('wednesday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('thursday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('friday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                        <td class="py-2">
+                          <v-icon
+                            v-if="office.selected_flags.includes('saturday')"
+                            class="d-flex"
+                            >mdi-close</v-icon
+                          >
+                          <v-icon v-else class="d-flex" color="orange"
+                            >mdi-circle-outline</v-icon
+                          >
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </v-col>
             </v-row>
             <div class="mt-4 md-over-no holiday-detail">
@@ -129,7 +216,7 @@
                 <v-icon>mdi-map-marker</v-icon>
                 <div class="my-auto">東京駅 徒歩5分</div>
                 <v-icon>mdi-account</v-icon>
-                <div class="my-auto">スタッフ数 人</div>
+                <div class="my-auto">スタッフ数 {{ staffs.length }}人</div>
               </div>
             </v-col>
             <v-col class="pt-0" md="12" xs="6">
@@ -156,7 +243,93 @@
               <div class="holiday-pc">営業日</div>
             </v-col>
             <v-col>
-              <div></div>
+              <div>
+                <table>
+                  <tbody>
+                    <tr>
+                      <th>日</th>
+                      <th>月</th>
+                      <th>火</th>
+                      <th>水</th>
+                      <th>木</th>
+                      <th>金</th>
+                      <th>土</th>
+                    </tr>
+                    <tr>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('sunday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('monday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('tuesday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('wednesday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('thursday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('friday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                      <td class="py-2">
+                        <v-icon
+                          v-if="office.selected_flags.includes('saturday')"
+                          class="d-flex"
+                          >mdi-close</v-icon
+                        >
+                        <v-icon v-else class="d-flex" color="orange"
+                          >mdi-circle-outline</v-icon
+                        >
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
               <div class="mt-4 mb-4 holiday-detail">
                 {{ office.business_day_detail }}
               </div>
@@ -175,10 +348,14 @@ export default {
     return {
       office_id: this.$route.params.id,
       active: 0, // 事業所画像が現在何番目か
+      getAPI: {},
       office: {
         selected_flags: '',
         images: [],
       },
+      images: {},
+      staffs: {},
+      noImageURL: '~/assets/images/no_image.jpeg',
     }
   },
   mounted() {
@@ -188,7 +365,10 @@ export default {
     async getOffice() {
       try {
         const response = await this.$axios.$get(`offices/${this.office_id}`)
-        this.office = response
+        this.getAPI = response
+        this.office = this.getAPI.office
+        this.images = this.getAPI.images
+        this.staffs = this.getAPI.staffs
       } catch (error) {
         return error
       }

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -3,7 +3,7 @@
     <v-row>
       <v-col cols="12" sm="12" md="6">
         <v-card outlined tile height="338">
-          <v-img :src="office.image_url[active]" height="338">
+          <v-img :src="office.images[active]" height="338">
             <v-row>
               <v-col cols="6">
                 <v-btn
@@ -37,14 +37,14 @@
         <v-card class="sm-under-no" outlined tile height="85">
           <div class="thumbnails">
             <li
-              v-for="index in office.image_url.length"
+              v-for="index in office.images.length"
               :key="index"
               :class="{ current: active === index - 1 }"
               class="mx-1"
               @click="current(index)"
             >
               <v-img
-                :src="office.image_url[index - 1]"
+                :src="office.images[index - 1]"
                 height="50"
                 width="70"
               ></v-img>
@@ -70,14 +70,14 @@
               <v-icon>mdi-map-marker</v-icon>
               <div class="my-auto">東京駅 徒歩5分</div>
               <v-icon>mdi-account</v-icon>
-              <div class="my-auto">スタッフ数 {{ staffs.length }}人</div>
+              <div class="my-auto">スタッフ数 {{ office.staffs.length }}人</div>
             </div>
           </v-col>
           <v-col class="pt-0" md="12" xs="6">
-            <v-icon large>mdi-phone</v-icon>{{ office.phone_number }}
+            <v-icon large>mdi-phone</v-icon>{{ office.office.phone_number }}
             <div class="flex">
               <div class="fax pr-1">FAX</div>
-              <div class="my-auto">{{ office.fax_number }}</div>
+              <div class="my-auto">{{ office.office.fax_number }}</div>
             </div>
           </v-col>
           <v-col cols="12"
@@ -104,7 +104,9 @@
                       <tr>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('sunday')"
+                            v-if="
+                              office.office.selected_flags.includes('sunday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -114,7 +116,9 @@
                         </td>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('monday')"
+                            v-if="
+                              office.office.selected_flags.includes('monday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -124,7 +128,9 @@
                         </td>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('tuesday')"
+                            v-if="
+                              office.office.selected_flags.includes('tuesday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -134,7 +140,9 @@
                         </td>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('wednesday')"
+                            v-if="
+                              office.office.selected_flags.includes('wednesday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -144,7 +152,9 @@
                         </td>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('thursday')"
+                            v-if="
+                              office.office.selected_flags.includes('thursday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -154,7 +164,9 @@
                         </td>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('friday')"
+                            v-if="
+                              office.office.selected_flags.includes('friday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -164,7 +176,9 @@
                         </td>
                         <td class="py-2">
                           <v-icon
-                            v-if="office.selected_flags.includes('saturday')"
+                            v-if="
+                              office.office.selected_flags.includes('saturday')
+                            "
                             class="d-flex"
                             >mdi-close</v-icon
                           >
@@ -179,14 +193,16 @@
               </v-col>
             </v-row>
             <div class="mt-4 md-over-no holiday-detail">
-              {{ office.business_day_detail }}
+              {{ office.office.business_day_detail }}
             </div>
           </v-col>
         </v-card>
         <v-card class="mt-6" outlined tile height="491">
-          <v-col class="office-title" cols="12">{{ office.title }} </v-col>
+          <v-col class="office-title" cols="12"
+            >{{ office.office.title }}
+          </v-col>
           <v-col class="title_detail" cols="12"
-            >{{ office.title_detail }}
+            >{{ office.office.title_detail }}
           </v-col>
         </v-card>
         <v-card class="mt-6" outlined tile height="599">
@@ -199,7 +215,9 @@
       <v-col cols="12" sm="12" md="6">
         <v-card class="sm-under-no sticky" outlined tile>
           <v-row class="mx-auto mt-auto max-width">
-            <v-col class="office-name" cols="10">{{ office.name }} </v-col>
+            <v-col class="office-name" cols="10"
+              >{{ office.office.name }}
+            </v-col>
             <v-col class="pl-0" ols="2">
               <v-btn fab depressed>
                 <v-icon large color="white">mdi-star</v-icon>
@@ -207,24 +225,26 @@
             </v-col>
             <v-col cols="12">
               <div class="office-tel">
-                〒{{ office.post_code }}
+                〒{{ office.office.post_code }}
                 <br />
-                {{ office.address }}
+                {{ office.office.address }}
               </div>
               <div class="mt-3 flex access-and-staff">
                 <v-icon>mdi-map-marker</v-icon>
                 <div class="my-auto">東京駅 徒歩5分</div>
                 <v-icon>mdi-account</v-icon>
-                <div class="my-auto">スタッフ数 {{ staffs.length }}人</div>
+                <div class="my-auto">
+                  スタッフ数 {{ office.staffs.length }}人
+                </div>
               </div>
             </v-col>
             <v-col class="pt-0" md="12" xs="6">
               <div>
-                <v-icon large>mdi-phone</v-icon>{{ office.phone_number }}
+                <v-icon large>mdi-phone</v-icon>{{ office.office.phone_number }}
               </div>
               <div class="flex">
                 <div class="fax pr-1">FAX</div>
-                <div class="my-auto">{{ office.fax_number }}</div>
+                <div class="my-auto">{{ office.office.fax_number }}</div>
               </div>
             </v-col>
             <v-col cols="12">
@@ -257,7 +277,7 @@
                     <tr>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('sunday')"
+                          v-if="office.office.selected_flags.includes('sunday')"
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -267,7 +287,7 @@
                       </td>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('monday')"
+                          v-if="office.office.selected_flags.includes('monday')"
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -277,7 +297,9 @@
                       </td>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('tuesday')"
+                          v-if="
+                            office.office.selected_flags.includes('tuesday')
+                          "
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -287,7 +309,9 @@
                       </td>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('wednesday')"
+                          v-if="
+                            office.office.selected_flags.includes('wednesday')
+                          "
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -297,7 +321,9 @@
                       </td>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('thursday')"
+                          v-if="
+                            office.office.selected_flags.includes('thursday')
+                          "
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -307,7 +333,7 @@
                       </td>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('friday')"
+                          v-if="office.office.selected_flags.includes('friday')"
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -317,7 +343,9 @@
                       </td>
                       <td class="py-2">
                         <v-icon
-                          v-if="office.selected_flags.includes('saturday')"
+                          v-if="
+                            office.office.selected_flags.includes('saturday')
+                          "
                           class="d-flex"
                           >mdi-close</v-icon
                         >
@@ -330,7 +358,7 @@
                 </table>
               </div>
               <div class="mt-4 mb-4 holiday-detail">
-                {{ office.business_day_detail }}
+                {{ office.office.business_day_detail }}
               </div>
             </v-col>
           </v-row>
@@ -349,30 +377,18 @@ export default {
       active: 0, // 事業所画像が現在何番目か
       office: {
         selected_flags: '',
-        image_url: [],
+        images: [],
       },
-      staffs: {},
     }
   },
   mounted() {
     this.getOffice()
-    this.getStaffs()
   },
   methods: {
     async getOffice() {
       try {
         const response = await this.$axios.$get(`offices/${this.office_id}`)
         this.office = response
-      } catch (error) {
-        return error
-      }
-    },
-    async getStaffs() {
-      try {
-        const response = await this.$axios.$get(
-          `specialists/offices/${this.office_id}/staffs`
-        )
-        this.staffs = response
       } catch (error) {
         return error
       }
@@ -386,7 +402,7 @@ export default {
     prev() {
       // activeが0以下なら一番最後の画像へもどる
       if (this.active <= 0) {
-        this.active = this.office.image_url.length - 1
+        this.active = this.office.images.length - 1
       } else {
         this.active--
       }
@@ -395,14 +411,18 @@ export default {
     next() {
       // 配列の数が0~5つで6つになるので、-1とする
       // 5番目のときにnextしたら0番目に戻る
-      if (this.active >= this.office.image_url.length - 1) {
+      if (this.active >= this.office.images.length - 1) {
         this.active = 0
       } else {
         this.active++
       }
     },
     goAppointmentsPage() {
-      this.$router.push(`/offices/${this.office_id}/appointments`)
+      if (!this.$auth.loggedIn) {
+        return alert('ログインをする必要があります')
+      } else {
+        this.$router.push(`/offices/${this.office_id}/appointments`)
+      }
     },
   },
 }

--- a/pages/specialists/office/_office_id/care-recipients/new.vue
+++ b/pages/specialists/office/_office_id/care-recipients/new.vue
@@ -265,7 +265,6 @@ export default {
   methods: {
     async getStaffs() {
       try {
-        // this.$setId(this.office_id)
         const response = await this.$axios.$get(
           `specialists/offices/${this.office_id}/staffs`
         )

--- a/pages/specialists/office/_office_id/edit.vue
+++ b/pages/specialists/office/_office_id/edit.vue
@@ -12,7 +12,6 @@ export default {
   data() {
     return {
       office_id: this.$route.params.office_id,
-      res_office_id: '',
       office: [],
     }
   },
@@ -25,9 +24,8 @@ export default {
         const response = await this.$axios.$get(
           `specialists/offices/${this.office.id}`
         )
-        this.res_office_id = response.id
-        if (this.res_office_id - this.office_id !== 0) {
-          this.$router.push(`/specialists/office/${this.res_office_id}/edit`)
+        if (response.id - this.office_id !== 0) {
+          this.$router.push(`/specialists/office/${response.id}/edit`)
         } else {
           this.office = response
         }

--- a/pages/specialists/office/_office_id/edit.vue
+++ b/pages/specialists/office/_office_id/edit.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-card class="mx-auto mb-2 p-0" width="750" height="338">
+    <div>事業所編集画面<br /></div>
+    <div>事業所名：{{ office.name }}</div>
+  </v-card>
+</template>
+
+<script>
+export default {
+  layout: 'application_specialists',
+  middleware: 'authentication',
+  data() {
+    return {
+      office_id: this.$route.params.office_id,
+      res_office_id: '',
+      office: [],
+    }
+  },
+  mounted() {
+    this.getOffice()
+  },
+  methods: {
+    async getOffice() {
+      try {
+        const response = await this.$axios.$get(
+          `specialists/offices/${this.office.id}`
+        )
+        this.res_office_id = response.id
+        if (this.res_office_id - this.office_id !== 0) {
+          this.$router.push(`/specialists/office/${this.res_office_id}/edit`)
+        } else {
+          this.office = response
+        }
+      } catch (error) {
+        return error
+      }
+    },
+  },
+}
+</script>

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -69,12 +69,26 @@ export default {
     return {
       staffs: [],
       office_id: this.$route.params.office_id,
+      office: [],
     }
   },
   mounted() {
+    this.getOffice()
     this.getStaffs()
   },
   methods: {
+    async getOffice() {
+      try {
+        const response = await this.$axios.$get(
+          `specialists/offices/${this.office.id}`
+        )
+        if (response.id - this.office_id !== 0) {
+          this.$router.push(`/specialists/office/${response.id}/staffs`)
+        }
+      } catch (error) {
+        return error
+      }
+    },
     async getStaffs() {
       try {
         // this.$setId(this.office_id)

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -91,7 +91,6 @@ export default {
     },
     async getStaffs() {
       try {
-        // this.$setId(this.office_id)
         const response = await this.$axios.$get(
           `specialists/offices/${this.office_id}/staffs`
         )

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -605,6 +605,7 @@ export default {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
         localStorage.setItem('office_data', 'true')
+        this.$router.push('/specialists/office/1/edit')
       } catch (error) {
         return error
       }


### PR DESCRIPTION
## やったこと

- WEB予約完了画面実装　登録リクエスト送信
- 事業所詳細画面　コンソールエラー修正
- 事業所詳細画面　事業所画像がないときは**NO IMAGE**画像を表示
- 「WEB予約する」ボタンを押したときに未ログインの場合はアラート表示
- 事業所登録時に編集画面に遷移
- ヘッダーから事業所登録画面・編集画面・スタッフ一覧画面に遷移（URLの事業所IDは、変えても必ずケアマネが持ってる事業所のIDに強制的に遷移します）

## やらないこと

- スタッフ登録画面と編集画面で、事業所のIDを変えたときに強制的に事業所のIDのリンクに遷移すること（必要ないと判断したため）

## できるようになること（ユーザ目線）

- ヘッダーから事業所登録・編集・スタッフ一覧画面に遷移できる
- ヘッダーからスタッフ一覧画面に遷移後、スタッフ登録・編集・削除ができる
- 事業所登録後に画面遷移し、ケアマネが次の操作をスムーズに行える

## できなくなること（ユーザ目線）

- なし

## 動作確認 loom手順
- 上から順に動画を見てください
[事業所登録画面]
**すでに登録済みの場合はRailsのコンソールで削除すること**
 http://localhost:8000/specialists/office/new

[事業所登録後、事業所編集画面遷移 ヘッダーからも遷移（PC・スマホ対応）](https://www.loom.com/share/db33f159bb3343dea715f4dce4ba450e)

[事業所登録してないと使えない機能はヘッダーからアクセスできない](https://www.loom.com/share/79b8246016cd4112be4e5f27e2924cc3)

[WEB予約 手順](https://www.loom.com/share/5aa5fbfe55154ab7b3eb28b81efd74a3)
- WEB予約後、APIでデータが登録されているか確認する
```ruby
docker-compose exec web bash
rails c
Appointment.all
```
- 事業所の画像を登録してない場合は、NOIMAGEという画像が入る
![image](https://user-images.githubusercontent.com/34031637/174191064-c7d2d3f6-2dd5-4011-91f9-3e8dcbecccfd.png)


### 確認書類

[画面図 WEB予約完了画面PC](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/0df9ee79-2664-48ce-9064-82488f518a1c/specs/)
[画面図 WEB予約完了画面SP](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/e0499c4a-6701-4b7c-b568-7d9ebba60be7/specs/)
[画面一覧書](https://docs.google.com/spreadsheets/d/1zBUODbQx18IKoKiNmmvuOu6PvCYvTNH5-YTG1JIAcOQ/edit#gid=334611837)
[シナリオテスト](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1509308895)

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointsment-success
```

## シナリオテスト
以下シナリオテストを、ログイン時と非ログイン時で行う

⑱【ケアマネ】⑯から事業所の登録
9 4から事業所詳細画面に行き予約
8 3から事業所を選択し予約
２１．16からケアマネがスタッフ登録
２２．16からケアマネがスタッフ編集
２２．16からケアマネがスタッフ削除

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
