### PR TITLE
build: 予約履歴画面作成

### DIFF
--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -33,7 +33,7 @@
                       >ブックマーク</NuxtLink
                     >
                     <NuxtLink
-                      to="#"
+                      to="/appointments"
                       class="header-style text-overline text-decoration-none mr-5"
                       >予約履歴</NuxtLink
                     >
@@ -207,7 +207,7 @@
             <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20">
               <v-list-item-title>
                 <NuxtLink
-                  to="#"
+                  to="/appointments"
                   class="text-decoration-none text-body-2 navi-style"
                   >予約履歴</NuxtLink
                 >

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -340,7 +340,7 @@ export default {
   data() {
     return {
       logoutInfo: {
-        redirecttUrl: '/top',
+        redirectUrl: '/top',
         valid: false,
       },
       justify: [],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,7 +41,11 @@ export default {
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [],
 
-  plugins: ['~/plugins/axios.js', '~/plugins/apiToRequestOfAddress.js'],
+  plugins: [
+    '~/plugins/axios.js',
+    '~/plugins/apiToRequestOfAddress.js',
+    '~plugins/dateFilter.js',
+  ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/pages/appointments/index.vue
+++ b/pages/appointments/index.vue
@@ -2,7 +2,6 @@
   <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
     <h3 class="pb-3">予約履歴</h3>
     <v-row>
-      <!-- オフィスを取得 -->
       <v-col
         v-for="(office, index) in getAPI"
         :key="index"
@@ -11,7 +10,6 @@
         class="px-0 pb-0 pt-0"
         @click="moveShow(office.id)"
       >
-        <!-- オフィスに紐づく予約を取得 -->
         <v-col v-for="(appointments, i) in office.appointments" :key="i">
           <v-card class="mx-auto">
             <v-col
@@ -41,7 +39,7 @@
                 </v-row>
                 <v-row class="pt-1">
                   <v-icon small>mdi-phone</v-icon>
-                  <div class="my-auto pl-1">080-1111-2222</div>
+                  <div class="my-auto pl-1">{{ office.phone_number }}</div>
                 </v-row>
               </v-col>
             </v-row>
@@ -60,7 +58,6 @@
               >事業所からの連絡をお待ち下さい</v-col
             >
           </v-card>
-          <p v-if="getAPI.length === 0">予約はありません</p>
         </v-col>
       </v-col>
       <v-col v-show="isShow">予約履歴はありません</v-col>

--- a/pages/appointments/index.vue
+++ b/pages/appointments/index.vue
@@ -1,0 +1,112 @@
+<template>
+  <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
+    <h3 class="pb-3">予約履歴</h3>
+    <v-row>
+      <!-- オフィスを取得 -->
+      <v-col
+        v-for="(office, index) in getAPI"
+        :key="index"
+        cols="12"
+        md="6"
+        class="px-0 pb-0 pt-0"
+        @click="moveShow(office.id)"
+      >
+        <!-- オフィスに紐づく予約を取得 -->
+        <v-col v-for="(appointments, i) in office.appointments" :key="i">
+          <v-card class="mx-auto">
+            <v-col
+              ><h3>{{ office.name }}</h3></v-col
+            >
+            <v-row>
+              <v-avatar tile width="120" height="90" class="ml-6 mt-4 mb-8">
+                <v-img
+                  v-if="office.image_url !== null"
+                  :src="office.image_url[0]"
+                ></v-img>
+                <v-img
+                  v-else
+                  src="https://home-care-navi-bucket.s3.ap-northeast-1.amazonaws.com/no_image.jpeg"
+                ></v-img>
+              </v-avatar>
+              <v-col cols="6" class="pl-5 pr-0 access-and-staff">
+                <v-row class="mt-1">
+                  <v-icon small>mdi-map-marker</v-icon>
+                  <div class="my-auto pl-1">東京駅 徒歩5分</div>
+                </v-row>
+                <v-row class="pt-1">
+                  <v-icon small>mdi-account</v-icon>
+                  <div class="my-auto pl-1">
+                    スタッフ数 {{ office.staffs.length }}人
+                  </div>
+                </v-row>
+                <v-row class="pt-1">
+                  <v-icon small>mdi-phone</v-icon>
+                  <div class="my-auto pl-1">080-1111-2222</div>
+                </v-row>
+              </v-col>
+            </v-row>
+            <v-divider class="mx-3"></v-divider>
+            <v-col class="mt-2 font-color-gray text-caption"
+              >予約した日時：{{ appointments.created_at | created_at }}</v-col
+            >
+            <v-col class="pb-0 font-color-gray font-weight-black text-caption"
+              >面談希望日時</v-col
+            >
+            <v-col class="py-0"
+              >{{ appointments.meet_date | meet_date }}
+              {{ appointments.meet_time }}</v-col
+            >
+            <v-col class="text-center pt-4 pb-6 font-color-gray"
+              >事業所からの連絡をお待ち下さい</v-col
+            >
+          </v-card>
+          <p v-if="getAPI.length === 0">予約はありません</p>
+        </v-col>
+      </v-col>
+      <v-col v-show="isShow">予約履歴はありません</v-col>
+    </v-row>
+  </v-col>
+</template>
+
+<script>
+export default {
+  layout: 'application',
+  middleware: 'authentication',
+  data() {
+    return {
+      getAPI: [],
+      isShow: false,
+    }
+  },
+  mounted() {
+    this.getAppointments()
+  },
+  methods: {
+    async getAppointments() {
+      try {
+        const response = await this.$axios.$get(`appointments`)
+        this.getAPI = response
+        if (this.getAPI.length === 0) {
+          this.isShow = true
+        } else {
+          this.isShow = false
+        }
+      } catch (error) {
+        return error
+      }
+    },
+    moveShow(id) {
+      this.$router.push({ path: `/offices/${id}` })
+    },
+  },
+}
+</script>
+<style scoped>
+.font-color-gray {
+  color: #6d7570;
+}
+
+.access-and-staff {
+  font-size: 12px;
+}
+</style>

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -82,7 +82,14 @@
             </div>
           </v-col>
           <v-col cols="12"
-            ><v-btn x-large block depressed color="error">WEB予約する</v-btn>
+            ><v-btn
+              x-large
+              block
+              depressed
+              color="error"
+              @click="goAppointmentsPage"
+              >WEB予約する</v-btn
+            >
           </v-col>
           <v-col>
             <v-row class="md-over-no">
@@ -382,7 +389,7 @@ export default {
     prev() {
       // activeが0以下なら一番最後の画像へもどる
       if (this.active <= 0) {
-        this.active = this.office.images.length - 1
+        this.active = this.images.length - 1
       } else {
         this.active--
       }
@@ -391,7 +398,7 @@ export default {
     next() {
       // 配列の数が0~5つで6つになるので、-1とする
       // 5番目のときにnextしたら0番目に戻る
-      if (this.active >= this.office.images.length - 1) {
+      if (this.active >= this.images.length - 1) {
         this.active = 0
       } else {
         this.active++

--- a/plugins/dateFilter.js
+++ b/plugins/dateFilter.js
@@ -1,0 +1,33 @@
+import Vue from 'vue'
+
+const appointmentDateFilter = (value) => {
+  return formatCreatedAt(value)
+}
+const meetDateFilter = (value) => {
+  return formatMeetDate(value)
+}
+
+function formatCreatedAt(getDate) {
+  const date = new Date(getDate)
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const hour = date.getHours()
+  const minutes = date.getMinutes()
+  const formattedDate = `${year}年${month}月${day}日 ${hour}:${minutes}`
+  return formattedDate
+}
+
+function formatMeetDate(getDate) {
+  const date = new Date(getDate)
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const week = date.getDay()
+  const weekStr = ['日', '月', '火', '水', '木', '金', '土'][week]
+  const formattedDate = `${year}年${month}月${day}日(${weekStr})`
+  return formattedDate
+}
+
+Vue.filter('created_at', appointmentDateFilter)
+Vue.filter('meet_date', meetDateFilter)


### PR DESCRIPTION
## やったこと

- 予約履歴画面作成
- カードをクリックすると、予約した事業所の詳細ページへ遷移
- 予約履歴がなければ「予約履歴はありません」と表示する

## やらないこと

- なし

## できるようになること（ユーザ目線）

- ユーザーが予約履歴を見れる

## できなくなること（ユーザ目線）

- なし

# **必要なかったら消すこと**

### API 側
- こちらのプルリクで動作確認をお願いします
https://github.com/koki-takishita/home-care-navi-api/pull/70

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointments_history
```

### 動作確認 Loom 手順

- 手順動画をご覧ください
  [予約履歴画面 手順動画](https://www.loom.com/share/1da59b251ced4f8da661e64c391f8abb)

### 確認書類

[画面図](https://docs.google.com/spreadsheets/d/1zBUODbQx18IKoKiNmmvuOu6PvCYvTNH5-YTG1JIAcOQ/edit#gid=334611837)
[XD 予約履歴画面 PC](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/7c5bcd66-02a0-41f0-b2d3-657d857752b0/)
[XD 予約履歴画面 SP](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/ac3d0418-5ab8-49f9-be8f-8bbdee53e26c)

