### PR TITLE
build: topページから現在地を取得できる

### DIFF
--- a/components/ChooseAreaCard.vue
+++ b/components/ChooseAreaCard.vue
@@ -3,7 +3,13 @@
     <div class="d-none d-md-block">
       <div class="w-390">
         <v-card min-height="324" max-width="375" class="pa-4" outlined>
-          <v-btn block color="error" min-height="48" outlined>
+          <v-btn
+            block
+            color="error"
+            min-height="48"
+            outlined
+            @click="clickBtn(btnType.location)"
+          >
             <v-icon small>mdi-map-marker</v-icon>
             <span class="font-weight-black ml-2">現在地から探す</span>
           </v-btn>
@@ -38,7 +44,13 @@
           ></v-text-field>
         </div>
         <v-divider class="pa-0 mt-5 mb-5"></v-divider>
-        <v-btn block color="error" min-height="48" outlined>
+        <v-btn
+          block
+          color="error"
+          min-height="48"
+          outlined
+          @click="clickBtn(btnType.location)"
+        >
           <v-icon small>mdi-map-marker</v-icon>
           <span class="font-weight-black ml-2">現在地から探す</span>
         </v-btn>
@@ -81,6 +93,9 @@ export default {
         '九州沖縄',
       ],
       display: true,
+      btnType: {
+        location: 'CurrentLocationBtn',
+      },
     }
   },
   computed: {
@@ -102,6 +117,9 @@ export default {
       'set_one_city',
       'set_one_prefecture',
     ]),
+    clickBtn(type) {
+      this.$emit(`click${type}`)
+    },
     fetchAreas(chooseArea) {
       this.set_one_city()
       this.set_one_prefecture()

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -7,7 +7,7 @@
       </p>
     </div>
     <div :class="toggleClassByBreakpoints">
-      <ChooseAreaCard />
+      <ChooseAreaCard @clickCurrentLocationBtn="searchOfficeLocation()" />
       <ChoosePrefectureCard />
       <ChooseCityCard />
     </div>
@@ -31,6 +31,41 @@ export default {
       } else {
         return this.pcStyle
       }
+    },
+  },
+  methods: {
+    searchOfficeLocation() {
+      this.getPositon()
+    },
+    getPositon() {
+      navigator.geolocation.getCurrentPosition(this.success)
+    },
+    success(pos) {
+      const crd = pos.coords
+      this.searchLocation(crd.longitude, crd.latitude)
+    },
+    async searchLocation(x, y) {
+      try {
+        const response = await this.$apiToAddressJson.$get(
+          `json?method=searchByGeoLocation&x=${x}&y=${y}`
+        )
+        const prefecture = response.response.location[0].prefecture
+        const city = response.response.location[0].city
+        this.searchOfficeFromArea(encodeURI(prefecture), encodeURI(city), true)
+      } catch (error) {
+        // console.log(error)
+        return error
+      }
+    },
+    searchOfficeFromArea(prefecture, city, location) {
+      this.$router.push({
+        path: '/offices',
+        query: {
+          prefecture,
+          cities: city,
+          location,
+        },
+      })
     },
   },
 }


### PR DESCRIPTION
## やったこと

- このプルリクで何をしたのか？

1. トップページから現在地が取得できるようにした

## やらないこと

1. プラグイン化はまだしてない

## できるようになること（ユーザ目線）

1. トップページから現在地が取得できる

## できなくなること（ユーザ目線）

なし

## 動作確認
※ 下記の住所のオフィスが存在していること `rasil db:seed`をすれば入る 都合悪い方は自前で作成お願いします
```ruby
address: 新潟県佐渡市秋津
```
### Front 側

- fetch and checkout
```ruby
git fetch && git checkout origin/feature/search-to-current-area-for-office
```
1. トップページから現在地から探すボタン押す
2. 一覧へ遷移
3. 現在地の住所のオフィスが取得できる
[![Image from Gyazo](https://i.gyazo.com/bb1cc538fc41ce9739b6e89f14d6925a.gif)](https://gyazo.com/bb1cc538fc41ce9739b6e89f14d6925a)

## その他

押したあと3秒くらい時間かかります。