### PR TITLE
build: プルリク指摘箇所修正

### DIFF
--- a/pages/specialists/office/_office_id/care-recipients/_care_recipient_id/edit.vue
+++ b/pages/specialists/office/_office_id/care-recipients/_care_recipient_id/edit.vue
@@ -145,7 +145,7 @@
             color="warning"
             @click="send"
           >
-            登録する
+            変更する
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
@@ -166,7 +166,6 @@ export default {
   data() {
     return {
       staffs: [],
-      // officeId: this.$route.params.office_id,
       formValidates: {
         required: (value) => !!value || '必須項目です',
         fileSizeCheck: (value) =>
@@ -274,7 +273,6 @@ export default {
   methods: {
     async getCareRecipients() {
       try {
-        // this.$setId(this.office_id)
         const response = await this.$axios.$get(
           `specialists/offices/${this.office_id}/care_recipients/${this.care_recipient_id}`
         )
@@ -317,8 +315,6 @@ export default {
             headers: { 'Content-Type': 'multipart/form-data' },
           }
         )
-        this.$store.commit('catchErrorMsg/setType', 'success')
-        this.$store.commit('catchErrorMsg/setMsg', ['登録しました'])
         this.$router.push('..')
       } catch (error) {
         return error

--- a/pages/specialists/office/_office_id/care-recipients/new.vue
+++ b/pages/specialists/office/_office_id/care-recipients/new.vue
@@ -296,8 +296,6 @@ export default {
             headers: { 'Content-Type': 'multipart/form-data' },
           }
         )
-        this.$store.commit('catchErrorMsg/setType', 'success')
-        this.$store.commit('catchErrorMsg/setMsg', ['登録しました'])
         this.$router.push('.')
       } catch (error) {
         return error


### PR DESCRIPTION
## やったこと

### 午前中指摘あった箇所の修正

瀧下さん:編集画面のボタンが『登録する』になっていた　→　『変更する』に修正
渡邊さん：利用者の登録と編集完了時にフラッシュメッセージが一瞬だけ出てますが、すぐ消えてしまうので不要だと思います。 → フラッシュメッセージ表示しない

## できるようになること（ユーザ目線）

1不自然な箇所がなくなる

## 動作確認

###  API側

- fetch and checkout

```ruby
git fetch && git checkout origin/develop
```


### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/care-recipients_front
```

### Loom 手順

編集画面（登録後のフラッシュメッセージ、ボタンの確認）[手順動画](https://www.loom.com/share/5ba1474b7ed3431faee8a148854cddd1)
登録画面（登録後のフラッシュメッセージ）[手順動画](https://www.loom.com/share/3430cef76e4d4886aa91f0402bd8b9be)

## その他

前回のプルリク　https://github.com/koki-takishita/home-care-navi-front/pull/153
不明点あればおっしゃってください

　