### PR TITLE
予約履歴画面並び順崩れ修正

### DIFF
--- a/pages/appointments/index.vue
+++ b/pages/appointments/index.vue
@@ -1,16 +1,18 @@
 <template>
   <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
     <h3 class="pb-3">予約履歴</h3>
-    <v-row>
-      <v-col
-        v-for="(office, index) in getAPI"
-        :key="index"
-        cols="12"
-        md="6"
-        class="px-0 pb-0 pt-0"
-        @click="moveShow(office.id)"
-      >
-        <v-col v-for="(appointments, i) in office.appointments" :key="i">
+    <v-col
+      v-for="(office, index) in getAPI"
+      :key="index"
+      @click="moveShow(office.id)"
+    >
+      <v-row>
+        <v-col
+          v-for="(appointments, i) in office.appointments"
+          :key="i"
+          cols="12"
+          md="6"
+        >
           <v-card class="mx-auto">
             <v-col
               ><h3>{{ office.name }}</h3></v-col
@@ -59,12 +61,11 @@
             >
           </v-card>
         </v-col>
-      </v-col>
-      <v-col v-show="isShow">予約履歴はありません</v-col>
-    </v-row>
+      </v-row>
+    </v-col>
+    <v-col v-show="isShow">予約履歴はありません</v-col>
   </v-col>
 </template>
-
 <script>
 export default {
   layout: 'application',


### PR DESCRIPTION
## やったこと

- 予約履歴が縦1列に並んでしまう不具合修正

## やらないこと

- 予約履歴が新しいものが先頭に来るような並び替え（負債扱い。来週以降対応予定）

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointments_history
```

### 動作確認 Loom 手順

**rails:db:seedが完了していることが前提です**
- もし、seedが実行済みで下記の手順を行っていなければ、下記の手順を実行
```ruby
u = User.first
```
```ruby
u.user_type = 0
```
```ruby
u.save
```
- ユーザーとしてログインする
```ruby
customer0@example.com
```
```ruby
password
```
- ヘッダーから予約履歴画面にアクセスし、PC版であれば横2列に正しく並べられているか確認する
![image](https://user-images.githubusercontent.com/34031637/175440047-aa115dbf-b968-483a-abea-428638190cc7.png)

### その他
- 別の事業所を複数予約すると、縦にならんでしまう。今日は間に合わないので、後日対応
![image](https://user-images.githubusercontent.com/34031637/175442257-e5dfe481-3551-42b8-a335-d2656279abe5.png)

