### PR TITLE
fix: 休日の表反転していたので修正

### DIFF
--- a/components/office/officeCard.vue
+++ b/components/office/officeCard.vue
@@ -132,6 +132,7 @@ export default {
       },
       week: ['日', '月', '火', '水', '木', '金', '土'],
       binaryNumber: [64, 32, 16, 8, 4, 2, 1],
+      // binaryNumber: [1, 2, 4, 8, 16, 32, 64],
     }
   },
   computed: {
@@ -204,7 +205,7 @@ export default {
           arry.push(0)
         }
       })
-      return arry
+      return arry.reverse()
     },
     toggleSymbol(n) {
       return n === 1 ? 'mdi-close' : 'mdi-circle-outline'


### PR DESCRIPTION
## プルリクルール守ってね

[プルリクルール](https://docs.google.com/spreadsheets/d/1XXQGmsRkmIlOpTE6KN6sx6Uya4u_lGKgscMaRdBZDzA/edit#gid=0)

## やったこと

1. 休日の◯ ✕表示が反転していたのでそれの修正

## やらないこと

なし

## できるようになること（ユーザ目線）

間違った表示の解消

## できなくなること（ユーザ目線）

なし

## 動作確認

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/bugfix/calendar-logic
```
[トップページに飛びます(localhost:8000/top)](http://localhost:8000/top)

1. オフィス一覧にアクセスする
2. 一覧の◯✕の組み合わせを覚えておく
3. 詳細と組み合わせが一緒なことを確認する
### Loom 手順
[手順動画](https://www.loom.com/share/1fb42ab1fe314a099a5e9ec573051fc5)

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
