### PR TITLE
Test/user logout

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -21,6 +21,6 @@ module.exports = {
   server: {
     command: 'yarn testServer',
     port: 9000,
-    launchTimeout: 50000,
+    launchTimeout: 100000,
   },
 }

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -49,6 +49,7 @@
                     >
                     <div class="red--text line-style">
                       <v-btn
+                        id="header-logout"
                         :width="120"
                         :height="36"
                         color="error"
@@ -61,6 +62,7 @@
                 </div>
                 <div v-else class="red--text line-style">
                   <v-btn
+                    id="header-login"
                     href="/users/login"
                     :width="120"
                     :height="36"
@@ -69,6 +71,7 @@
                     >ログイン</v-btn
                   >
                   <v-btn
+                    id="header-sign-up"
                     href="/users/new"
                     :width="120"
                     :height="36"
@@ -136,6 +139,7 @@
                 class="d-flex justify-center ma-0 mt-6"
               >
                 <v-btn
+                  id="header-logout"
                   href="/users/login"
                   :width="120"
                   :height="36"
@@ -148,6 +152,7 @@
               </div>
               <div v-else class="d-flex justify-center ma-0 mt-6">
                 <v-btn
+                  id="header-login"
                   href="/users/login"
                   :width="120"
                   :height="36"
@@ -157,6 +162,7 @@
                   >ログイン</v-btn
                 >
                 <v-btn
+                  id="header-sign-up"
                   href="/users/new"
                   :width="120"
                   :height="36"

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -228,8 +228,8 @@ export default {
           phone_number: this.form.phone_number,
           post_code: this.form.post_code,
           address: this.form.address,
-          confirm_success_url: 'http://localhost:8000/top',
-          // confirm_success_url: 'http://localhost:9000/top',
+          // confirm_success_url: 'http://localhost:8000/top',
+          confirm_success_url: 'http://localhost:9000/top',
         })
         this.$router.push('/users/send')
         return response

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -228,8 +228,8 @@ export default {
           phone_number: this.form.phone_number,
           post_code: this.form.post_code,
           address: this.form.address,
-          // confirm_success_url: 'http://localhost:8000/top',
-          confirm_success_url: 'http://localhost:9000/top',
+          confirm_success_url: 'http://localhost:8000/top',
+          // confirm_success_url: 'http://localhost:9000/top',
         })
         this.$router.push('/users/send')
         return response

--- a/test/e2e/users/signUp_to_login.spec.js
+++ b/test/e2e/users/signUp_to_login.spec.js
@@ -1,19 +1,14 @@
+let page
+let url
+let text
+let ele
+let titleText
+const randomNum = require('../randomNum')
+let email
+const password = 'password'
 describe('ユーザーが新規登録してログインできる', () => {
-  let page
-  let url
-  let text
-  let ele
-  let titleText
-  const randomNum = require('../randomNum')
-  let email
-  const password = 'password'
-
   beforeAll(async () => {
     page = await browser.newPage()
-  })
-
-  afterAll(async () => {
-    await page.close()
   })
 
   it('TOP画面から新規登録ボタンを押し、新規登録画面に遷移する', async () => {
@@ -133,7 +128,30 @@ describe('ユーザーが新規登録してログインできる', () => {
     ])
     url = await page.mainFrame().url()
     text = await page.evaluate(() => document.body.textContent)
+    const logoutBtn = await page.$eval('#header-logout', (item) => {
+      return item.textContent
+    })
     await expect(url).toEqual('http://localhost:9000/top')
     await expect(text).toContain('安心して介護をお願いしたいから')
+    await expect(logoutBtn).toEqual('ログアウト')
+  })
+})
+
+describe('ユーザーがログアウトをする', () => {
+  afterAll(async () => {
+    await page.close()
+  })
+
+  it('ログアウトボタンを押し、ログアウトする', async () => {
+    await page.click('#header-logout')
+
+    url = await page.mainFrame().url()
+    text = await page.evaluate(() => document.body.textContent)
+    const loginBtn = await page.$eval('#header-login', (item) => {
+      return item.textContent
+    })
+    await expect(url).toEqual('http://localhost:9000/top')
+    await expect(text).toContain('安心して介護をお願いしたいから')
+    await expect(loginBtn).toEqual('ログイン')
   })
 })


### PR DESCRIPTION
## やったこと

- 環境によってテストが実行されない問題を、テストサーバーの初回起動のタイムアウト時間を50秒から100秒に変更したことで緩和した
- ユーザーのログアウトを自動化

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/user-logout
```


### 動作確認 Loom 手順

- `pages/users/new`を開き、231、232行目の`confirm_success_url`をテスト用の**localhost:9000**に切り替える
```javascript
methods: {
    ...mapActions('catchErrorMsg', ['clearMsg']),
    async sign_up() {
      try {
        const response = await this.$axios.$post(`users`, {
          (略)
          // confirm_success_url: 'http://localhost:8000/top',
          confirm_success_url: 'http://localhost:9000/top',
        })
        (略)
    },
  },
```
- テスト実行。自動でブラウザが開き、書いたテストがブラウザ上で実行される
```ruby
yarn test:e2e
```
- ログイン後に、ログアウトボタンが押され、ヘッダーにログインボタンと新規登録ボタンが表示されていれば成功

## テストが失敗してしまった場合
- 9000番ポートに現在接続しているものの一覧を出す
```ruby
lsof -i :9000
```
- 接続しているものがあれば、このように表示される(PIDは人によって変わります)
```ruby
COMMAND  PID            (略)
node     0123 hogehoge  (略) 
```
- 接続を切る
```ruby
kill -QUIT <PID>
```
- 再度テストを実行
```ruby
yarn test:e2e
```
[【Nuxt.js】サーバ起動時にAddress already in use と表示されたときの対処](https://qiita.com/hiroyukiwk/items/57939f950aa5562bbf1c)
## その他
- ログアウト用のテストファイルを作りたかったのですが、最初にログアウトのテストが走ってしまい、テストが失敗してしまいました。暫定対応として、ユーザーの場合はテストの最後にログアウトをさせるようにしています。

イメージとしてはこのようになります。
新規登録→ログインまでのテストコードを書いた...ログイン後にログアウトさせる
ログイン後に事業所検索をさせるテストコードを書いた...事業所検索後にログアウトさせる

- ファイル名のパターンに基づいてテストが実行されている とのこと
[Jestで順番にPuppeteerテストを実行する](https://stackoverflow.com/questions/54470338/running-puppeteer-tests-in-order-with-jest)
