### PR TITLE
build: 事業所登録 自動テスト

### DIFF
--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -2,4 +2,5 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/test/e2e/setup.js'],
   verbose: true,
   preset: 'jest-puppeteer',
+  testSequencer: '<rootDir>/test/e2e/testSequencer.js',
 }

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -7,6 +7,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >事業所名
             <v-text-field
+              id="name"
               v-model="name"
               :rules="[formValidates.required, formValidates.nameCountCheck]"
               class="mt-2 font-weight-regular"
@@ -18,6 +19,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >特徴タイトル
             <v-text-field
+              id="title"
               v-model="title"
               :rules="[formValidates.required, formValidates.titleCountCheck]"
               class="mt-2 font-weight-regular"
@@ -29,6 +31,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >特徴詳細
             <v-textarea
+              id="title_detail"
               v-model="title_detail"
               :rules="[formValidates.required, formValidates.textCountCheck]"
               class="mt-2 font-weight-regular"
@@ -60,6 +63,7 @@
             <v-col cols="1" class="mx-5"
               ><div class="ml-1">日</div>
               <v-checkbox
+                id="日"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="日"
@@ -70,6 +74,7 @@
             <v-col cols="1" class="mx-5"
               >月
               <v-checkbox
+                id="月"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="月"
@@ -80,6 +85,7 @@
             <v-col cols="1" class="mx-5"
               >火
               <v-checkbox
+                id="火"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="火"
@@ -90,6 +96,7 @@
             <v-col cols="1" class="mx-5"
               >水
               <v-checkbox
+                id="水"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="水"
@@ -100,6 +107,7 @@
             <v-col cols="1" class="mx-5"
               >木
               <v-checkbox
+                id="木"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="木"
@@ -110,6 +118,7 @@
             <v-col cols="1" class="mx-5"
               >金
               <v-checkbox
+                id="金"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="金"
@@ -120,6 +129,7 @@
             <v-col cols="1" class="mx-5"
               >土
               <v-checkbox
+                id="土"
                 v-model="selected"
                 :rules="[formValidates.holidayLengthCheck]"
                 value="土"
@@ -134,6 +144,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >営業日に関する説明
             <v-textarea
+              id="business_day_detail"
               v-model="business_day_detail"
               :rules="[
                 formValidates.required,
@@ -150,6 +161,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >電話番号
             <v-text-field
+              id="phone_number"
               v-model="phone_number"
               :rules="[formValidates.required, formValidates.phoneNumber]"
               class="mt-2 font-weight-regular"
@@ -161,6 +173,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >FAX
             <v-text-field
+              id="fax_number"
               v-model="fax_number"
               :rules="[formValidates.faxNumber]"
               class="mt-2 mb-2 font-weight-regular"
@@ -171,6 +184,7 @@
           /></label>
         </v-col>
         <v-text-field
+          id="post_code"
           v-model="post_code"
           :rules="[formValidates.required, formValidates.postCode]"
           outlined
@@ -188,6 +202,7 @@
         <v-col cols="12" class="pt-0">
           <div class="mt-n2">
             <v-text-field
+              id="address"
               v-model="address"
               :rules="[formValidates.required]"
               outlined
@@ -202,6 +217,7 @@
           <label class="font-color-gray font-weight-black text-caption"
             >類型
             <v-text-field
+              id="service_type"
               v-model="service_type"
               :rules="[
                 formValidates.required,
@@ -398,6 +414,7 @@
             </v-expansion-panel>
           </v-expansion-panels>
           <v-btn
+            id="send"
             x-large
             block
             depressed

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -228,8 +228,8 @@ export default {
           phone_number: this.form.phone_number,
           post_code: this.form.post_code,
           address: this.form.address,
-          confirm_success_url: 'http://localhost:8000/specialists/login',
-          // confirm_success_url: 'http://localhost:9000/specialists/login',
+          // confirm_success_url: 'http://localhost:8000/specialists/login',
+          confirm_success_url: 'http://localhost:9000/specialists/login',
         })
         this.$router.push('/specialists/users/send')
         return response

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -228,8 +228,8 @@ export default {
           phone_number: this.form.phone_number,
           post_code: this.form.post_code,
           address: this.form.address,
-          confirm_success_url: 'http://localhost:8000/top',
-          // confirm_success_url: 'http://localhost:9000/top',
+          // confirm_success_url: 'http://localhost:8000/top',
+          confirm_success_url: 'http://localhost:9000/top',
         })
         this.$router.push('/users/send')
         return response

--- a/test/e2e/specialists/A_signup_to_login.spec.js
+++ b/test/e2e/specialists/A_signup_to_login.spec.js
@@ -1,28 +1,50 @@
 let page
-let url
 let text
+let url
 let ele
 let titleText
 const randomNum = require('../randomNum')
 let email
 const password = 'password'
-describe('ユーザーが新規登録してログインできる', () => {
+describe('ケアマネージャーが新規登録してログインできる', () => {
   beforeAll(async () => {
     page = await browser.newPage()
   })
 
-  it('TOP画面から新規登録ボタンを押し、新規登録画面に遷移する', async () => {
+  afterAll(async () => {
+    await page.close()
+  })
+
+  it('TOP画面からログインボタンを押し、ユーザーのログイン画面に遷移する', async () => {
     await page.goto('http://localhost:9000/')
     url = await page.mainFrame().url()
     text = await page.evaluate(() => document.body.textContent)
     await expect(url).toEqual('http://localhost:9000/')
     await expect(text).toContain('安心して介護をお願いしたいから')
-    await page.click('a[href="/users/new"]')
+    await page.click('a[href="/users/login"]')
 
     url = await page.mainFrame().url()
     ele = await page.$('h6')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/users/new')
+    await expect(url).toEqual('http://localhost:9000/users/login')
+    await expect(titleText).toEqual('ログイン')
+  })
+
+  it('ユーザーのログイン画面から、ケアマネージャーのログイン画面に遷移する', async () => {
+    await page.click('a[href="/specialists/login/"]')
+    url = await page.mainFrame().url()
+    ele = await page.$('h6')
+    titleText = await page.evaluate((elm) => elm.textContent, ele)
+    await expect(url).toEqual('http://localhost:9000/specialists/login/')
+    await expect(titleText).toEqual('ログイン')
+  })
+
+  it('ログイン画面から、新規登録画面に遷移する', async () => {
+    await page.click('#header-signup')
+    url = await page.mainFrame().url()
+    ele = await page.$('h6')
+    titleText = await page.evaluate((elm) => elm.textContent, ele)
+    await expect(url).toEqual('http://localhost:9000/specialists/users/new')
     await expect(titleText).toEqual('新規登録')
   })
 
@@ -32,9 +54,9 @@ describe('ユーザーが新規登録してログインできる', () => {
 
     await page.click('#name')
     const name = require('../randomName')
-    await page.keyboard.sendCharacter(name('カスタマー'))
+    await page.keyboard.sendCharacter(name('スペシャリスト'))
     await page.click('#email')
-    email = 'customer' + randomNum(9999999, 1000) + '@example.com'
+    email = 'specialist' + randomNum(9999999, 1000) + '@example.com'
     await page.keyboard.sendCharacter(email)
     await page.click('#password')
     await page.keyboard.sendCharacter(password)
@@ -62,16 +84,8 @@ describe('ユーザーが新規登録してログインできる', () => {
     url = await page.mainFrame().url()
     ele = await page.$('h1')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/users/send')
+    await expect(url).toEqual('http://localhost:9000/specialists/users/send')
     await expect(titleText).toEqual('仮登録完了')
-  })
-
-  it('仮登録完了画面から、TOP画面に遷移する', async () => {
-    await page.click('a[href="../top"]')
-    url = await page.mainFrame().url()
-    text = await page.evaluate(() => document.body.textContent)
-    await expect(url).toEqual('http://localhost:9000/top')
-    await expect(text).toContain('安心して介護をお願いしたいから')
   })
 
   it('メールキャッチャーにアクセスし、届いたメールからアカウントの有効化をする', async () => {
@@ -93,25 +107,16 @@ describe('ユーザーが新規登録してログインできる', () => {
       return item.textContent
     })
     await expect(bodyText).toContain(email)
-    await expect(bodyText).toContain('カスタマー')
+    await expect(bodyText).toContain('スペシャリスト')
     await expect(bodyText).toContain('アカウントを有効化する')
     await page.click('a[href^="http://localhost:3000/api/users/confirmation?"]')
 
     url = await page.mainFrame().url()
-    text = await page.evaluate(() => document.body.textContent)
-    await expect(url).toEqual(
-      'http://localhost:9000/top?account_confirmation_success=true'
-    )
-    await expect(text).toContain('安心して介護をお願いしたいから')
-  })
-
-  it('TOP画面からログインボタンを押し、ログイン画面に遷移する', async () => {
-    await page.click('a[href="/users/login"]')
-    url = await page.mainFrame().url()
-    text = await page.evaluate(() => document.body.textContent)
     ele = await page.$('h6')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/users/login')
+    await expect(url).toEqual(
+      'http://localhost:9000/specialists/login?account_confirmation_success=true'
+    )
     await expect(titleText).toEqual('ログイン')
   })
 
@@ -122,37 +127,19 @@ describe('ユーザーが新規登録してログインできる', () => {
     await page.keyboard.sendCharacter(password)
   })
 
-  it('ログインボタンを押し、TOP画面に遷移する', async () => {
+  it('ログインボタンを押し、事業所登録画面に遷移する', async () => {
     await Promise.all([
       page.waitForNavigation({ timeout: 5000, waitUntil: 'load' }),
       await page.click('#login'),
     ])
     url = await page.mainFrame().url()
-    text = await page.evaluate(() => document.body.textContent)
+    ele = await page.$('h3')
+    titleText = await page.evaluate((elm) => elm.textContent, ele)
     const logoutBtn = await page.$eval('#header-logout', (item) => {
       return item.textContent
     })
-    await expect(url).toEqual('http://localhost:9000/top')
-    await expect(text).toContain('安心して介護をお願いしたいから')
+    await expect(url).toEqual('http://localhost:9000/specialists/office/new')
+    await expect(titleText).toContain('事業所登録')
     await expect(logoutBtn).toEqual('ログアウト')
-  })
-})
-
-describe('ユーザーがログアウトをする', () => {
-  afterAll(async () => {
-    await page.close()
-  })
-
-  it('ログアウトボタンを押し、ログアウトする', async () => {
-    await page.click('#header-logout')
-
-    url = await page.mainFrame().url()
-    text = await page.evaluate(() => document.body.textContent)
-    const loginBtn = await page.$eval('#header-login', (item) => {
-      return item.textContent
-    })
-    await expect(url).toEqual('http://localhost:9000/top')
-    await expect(text).toContain('安心して介護をお願いしたいから')
-    await expect(loginBtn).toEqual('ログイン')
   })
 })

--- a/test/e2e/specialists/B_create_office.spec.js
+++ b/test/e2e/specialists/B_create_office.spec.js
@@ -1,0 +1,65 @@
+let page
+let url
+let text
+let ele
+let titleText
+const randomNum = require('../randomNum')
+describe('ケアマネージャーが事業所を登録できる', () => {
+  beforeAll(async () => {
+    page = await browser.newPage()
+  })
+
+  afterAll(async () => {
+    await page.close()
+  })
+
+  it('事業所登録画面からフォームに値を入力する', async () => {
+    await page.goto('http://localhost:9000/specialists/office/new')
+    url = await page.mainFrame().url()
+    ele = await page.$('h3')
+    titleText = await page.evaluate((elm) => elm.textContent, ele)
+    await expect(url).toEqual('http://localhost:9000/specialists/office/new')
+    await expect(titleText).toContain('事業所登録')
+
+    await expect(await page.$eval('#send', (el) => el.disabled)).toBe(true)
+    await page.click('#name')
+    const name = require('../randomName')
+    await page.keyboard.sendCharacter(name('ケアパーク'))
+    await page.click('#title')
+    await page.keyboard.sendCharacter('事業所紹介タイトル')
+    await page.click('#title_detail')
+    await page.keyboard.sendCharacter('事業所の特徴テキスト')
+    await page.click('#日')
+    await page.click('#土')
+    await page.click('#business_day_detail')
+    await page.keyboard.sendCharacter('営業日に関する説明')
+    await page.click('#phone_number')
+    const phoneNumber =
+      '080' + '-' + randomNum(9999, 1000) + '-' + randomNum(9999, 1000)
+    await page.keyboard.sendCharacter(phoneNumber)
+    await page.click('#fax_number')
+    const faxNumber =
+      '090' + '-' + randomNum(9999, 1000) + '-' + randomNum(9999, 1000)
+    await page.keyboard.sendCharacter(faxNumber)
+    await page.click('#post_code')
+    const postCode = randomNum(999, 100) + '-' + randomNum(9999, 1000)
+    await page.keyboard.sendCharacter(postCode)
+    await page.click('#address')
+    await page.keyboard.sendCharacter('東京都世田谷区祖父谷4-3-15')
+    await page.click('#service_type')
+    await page.keyboard.sendCharacter('介護付きホーム')
+    await expect(await page.$eval('#send', (el) => el.disabled)).toBe(false)
+  })
+
+  it('登録ボタンを押し、登録後、事業所編集画面に遷移する', async () => {
+    await page.click('#send')
+    url = await page.mainFrame().url()
+    text = await page.evaluate(() => document.body.textContent)
+    // URLに含まれている事業所IDを取得できないため、部分一致でURLの確認を行う
+    await expect(url).toContain('http://localhost:9000/specialists/office')
+    await expect(url).toContain('edit')
+    await expect(text).toContain('事業所編集')
+    // 登録した事業所名が取得できているか
+    await expect(text).toContain('ケアパーク')
+  })
+})

--- a/test/e2e/specialists/C_footer_link_access.spec.js
+++ b/test/e2e/specialists/C_footer_link_access.spec.js
@@ -47,4 +47,20 @@ describe('ケアマネージャーがフッターのリンクにすべてアク�
     await expect(url).toEqual('http://localhost:9000/specialists/contacts/new')
     await expect(titleText).toEqual('お問い合わせ')
   })
+
+  describe('ケアマネージャーがログアウトをする', () => {
+    it('ログアウトボタンを押し、ログアウトする', async () => {
+      await page.click('#header-logout')
+
+      url = await page.mainFrame().url()
+      const loginBtn = await page.$eval('#header-login', (item) => {
+        return item.textContent
+      })
+      ele = await page.$('h6')
+      titleText = await page.evaluate((elm) => elm.textContent, ele)
+      await expect(url).toEqual('http://localhost:9000/specialists/login')
+      await expect(loginBtn).toEqual('ログイン')
+      await expect(titleText).toEqual('ログイン')
+    })
+  })
 })

--- a/test/e2e/testSequencer.js
+++ b/test/e2e/testSequencer.js
@@ -1,0 +1,12 @@
+const Sequencer = require('@jest/test-sequencer').default
+
+class CustomSequencer extends Sequencer {
+  sort(tests) {
+    // Test structure information
+    // https://github.com/facebook/jest/blob/6b8b1404a1d9254e7d5d90a8934087a9c9899dab/packages/jest-runner/src/types.ts#L17-L21
+    const copyTests = Array.from(tests)
+    return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1))
+  }
+}
+
+module.exports = CustomSequencer

--- a/test/e2e/users/A_signup_to_login.spec.js
+++ b/test/e2e/users/A_signup_to_login.spec.js
@@ -1,46 +1,32 @@
 let page
-let text
 let url
+let text
 let ele
 let titleText
 const randomNum = require('../randomNum')
 let email
 const password = 'password'
-describe('ケアマネージャーが新規登録してログインできる', () => {
+describe('ユーザーが新規登録してログインできる', () => {
   beforeAll(async () => {
     page = await browser.newPage()
   })
 
-  it('TOP画面からログインボタンを押し、ユーザーのログイン画面に遷移する', async () => {
+  afterAll(async () => {
+    await page.close()
+  })
+
+  it('TOP画面から新規登録ボタンを押し、新規登録画面に遷移する', async () => {
     await page.goto('http://localhost:9000/')
     url = await page.mainFrame().url()
     text = await page.evaluate(() => document.body.textContent)
     await expect(url).toEqual('http://localhost:9000/')
     await expect(text).toContain('安心して介護をお願いしたいから')
-    await page.click('a[href="/users/login"]')
+    await page.click('a[href="/users/new"]')
 
     url = await page.mainFrame().url()
     ele = await page.$('h6')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/users/login')
-    await expect(titleText).toEqual('ログイン')
-  })
-
-  it('ユーザーのログイン画面から、ケアマネージャーのログイン画面に遷移する', async () => {
-    await page.click('a[href="/specialists/login/"]')
-    url = await page.mainFrame().url()
-    ele = await page.$('h6')
-    titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/specialists/login/')
-    await expect(titleText).toEqual('ログイン')
-  })
-
-  it('ログイン画面から、新規登録画面に遷移する', async () => {
-    await page.click('#header-signup')
-    url = await page.mainFrame().url()
-    ele = await page.$('h6')
-    titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/specialists/users/new')
+    await expect(url).toEqual('http://localhost:9000/users/new')
     await expect(titleText).toEqual('新規登録')
   })
 
@@ -50,9 +36,9 @@ describe('ケアマネージャーが新規登録してログインできる', (
 
     await page.click('#name')
     const name = require('../randomName')
-    await page.keyboard.sendCharacter(name('スペシャリスト'))
+    await page.keyboard.sendCharacter(name('カスタマー'))
     await page.click('#email')
-    email = 'specialist' + randomNum(9999999, 1000) + '@example.com'
+    email = 'customer' + randomNum(9999999, 1000) + '@example.com'
     await page.keyboard.sendCharacter(email)
     await page.click('#password')
     await page.keyboard.sendCharacter(password)
@@ -80,8 +66,16 @@ describe('ケアマネージャーが新規登録してログインできる', (
     url = await page.mainFrame().url()
     ele = await page.$('h1')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/specialists/users/send')
+    await expect(url).toEqual('http://localhost:9000/users/send')
     await expect(titleText).toEqual('仮登録完了')
+  })
+
+  it('仮登録完了画面から、TOP画面に遷移する', async () => {
+    await page.click('a[href="../top"]')
+    url = await page.mainFrame().url()
+    text = await page.evaluate(() => document.body.textContent)
+    await expect(url).toEqual('http://localhost:9000/top')
+    await expect(text).toContain('安心して介護をお願いしたいから')
   })
 
   it('メールキャッチャーにアクセスし、届いたメールからアカウントの有効化をする', async () => {
@@ -103,16 +97,25 @@ describe('ケアマネージャーが新規登録してログインできる', (
       return item.textContent
     })
     await expect(bodyText).toContain(email)
-    await expect(bodyText).toContain('スペシャリスト')
+    await expect(bodyText).toContain('カスタマー')
     await expect(bodyText).toContain('アカウントを有効化する')
     await page.click('a[href^="http://localhost:3000/api/users/confirmation?"]')
 
     url = await page.mainFrame().url()
+    text = await page.evaluate(() => document.body.textContent)
+    await expect(url).toEqual(
+      'http://localhost:9000/top?account_confirmation_success=true'
+    )
+    await expect(text).toContain('安心して介護をお願いしたいから')
+  })
+
+  it('TOP画面からログインボタンを押し、ログイン画面に遷移する', async () => {
+    await page.click('a[href="/users/login"]')
+    url = await page.mainFrame().url()
+    text = await page.evaluate(() => document.body.textContent)
     ele = await page.$('h6')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual(
-      'http://localhost:9000/specialists/login?account_confirmation_success=true'
-    )
+    await expect(url).toEqual('http://localhost:9000/users/login')
     await expect(titleText).toEqual('ログイン')
   })
 
@@ -123,39 +126,18 @@ describe('ケアマネージャーが新規登録してログインできる', (
     await page.keyboard.sendCharacter(password)
   })
 
-  it('ログインボタンを押し、事業所登録画面に遷移する', async () => {
+  it('ログインボタンを押し、TOP画面に遷移する', async () => {
     await Promise.all([
       page.waitForNavigation({ timeout: 5000, waitUntil: 'load' }),
       await page.click('#login'),
     ])
     url = await page.mainFrame().url()
-    ele = await page.$('h3')
-    titleText = await page.evaluate((elm) => elm.textContent, ele)
+    text = await page.evaluate(() => document.body.textContent)
     const logoutBtn = await page.$eval('#header-logout', (item) => {
       return item.textContent
     })
-    await expect(url).toEqual('http://localhost:9000/specialists/office/new')
-    await expect(titleText).toContain('事業所登録')
+    await expect(url).toEqual('http://localhost:9000/top')
+    await expect(text).toContain('安心して介護をお願いしたいから')
     await expect(logoutBtn).toEqual('ログアウト')
-  })
-})
-
-describe('ケアマネージャーがログアウトをする', () => {
-  afterAll(async () => {
-    await page.close()
-  })
-
-  it('ログアウトボタンを押し、ログアウトする', async () => {
-    await page.click('#header-logout')
-
-    url = await page.mainFrame().url()
-    const loginBtn = await page.$eval('#header-login', (item) => {
-      return item.textContent
-    })
-    ele = await page.$('h6')
-    titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:9000/specialists/login')
-    await expect(loginBtn).toEqual('ログイン')
-    await expect(titleText).toEqual('ログイン')
   })
 })

--- a/test/e2e/users/B_footer_link_access.spec.js
+++ b/test/e2e/users/B_footer_link_access.spec.js
@@ -45,4 +45,18 @@ describe('ユーザーがフッターのリンクにすべてアクセスでき�
     await expect(url).toEqual('http://localhost:9000/users/contacts/new')
     await expect(titleText).toEqual('お問い合わせ')
   })
+  describe('ユーザーがログアウトをする', () => {
+    it('ログアウトボタンを押し、ログアウトする', async () => {
+      await page.click('#header-logout')
+
+      url = await page.mainFrame().url()
+      text = await page.evaluate(() => document.body.textContent)
+      const loginBtn = await page.$eval('#header-login', (item) => {
+        return item.textContent
+      })
+      await expect(url).toEqual('http://localhost:9000/top')
+      await expect(text).toContain('安心して介護をお願いしたいから')
+      await expect(loginBtn).toEqual('ログイン')
+    })
+  })
 })


### PR DESCRIPTION
## やったこと

- 事業所登録のテストを自動化
- アルファベット順

## やらないこと

- 画像アップロード（余裕あれば）

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/office-create
```

### 動作確認 Loom 手順

- `pages/users/new`を開き、231、232行目の`confirm_success_url`をテスト用の**localhost:9000**に切り替える
```javascript
methods: {
    ...mapActions('catchErrorMsg', ['clearMsg']),
    async sign_up() {
      try {
        const response = await this.$axios.$post(`users`, {
          (略)
          // confirm_success_url: 'http://localhost:8000/top',
          confirm_success_url: 'http://localhost:9000/top',
        })
        (略)
    },
  },
```
-  `pages/specialists/users/new`を開き、231、232行目の`confirm_success_url`をテスト用の**localhost:9000**に切り替える
```javascript
methods: {
    ...mapActions('catchErrorMsg', ['clearMsg']),
    async sign_up() {
      try {
        const response = await this.$axios.$post(`specialists/users`, {
          (略)
          // confirm_success_url: 'http://localhost:8000/specialists/login',
          confirm_success_url: 'http://localhost:9000/specialists/login',
        })
        (略)
      } 
    },
  },
```
- テスト実行。自動でブラウザが開き、書いたテストがブラウザ上で実行される
```ruby
yarn test:e2e
```
- すべてテストが成功すればOK
```javascript
yarn run v1.22.18
$ jest --config jest.e2e.config.js --runInBand ./test/e2e
 PASS  test/e2e/specialists/signUp_to_login.spec.js (52.965 s)
  ケアマネージャーが新規登録してログインできる
    ✓ TOP画面からログインボタンを押し、ユーザーのログイン画面に遷移する (4910 ms)
    ✓ ユーザーのログイン画面から、ケアマネージャーのログイン画面に遷移する (2560 ms)
    ✓ ログイン画面から、新規登録画面に遷移する (2582 ms)
    ✓ フォームに値を入力する (16254 ms)
    ✓ 登録ボタンを押し、仮登録完了画面に遷移する (2638 ms)
    ✓ メールキャッチャーにアクセスし、届いたメールからアカウントの有効化をする (8422 ms)
    ✓ フォームに値を入力する (4393 ms)
    ✓ ログインボタンを押し、事業所登録画面に遷移する (3469 ms)
  ケアマネージャーがログアウトをする
    ✓ ログアウトボタンを押し、ログアウトする (3050 ms)

 PASS  test/e2e/users/signUp_to_login.spec.js (51.387 s)
  ユーザーが新規登録してログインできる
    ✓ TOP画面から新規登録ボタンを押し、新規登録画面に遷移する (4016 ms)
    ✓ フォームに値を入力する (16214 ms)
    ✓ 登録ボタンを押し、仮登録完了画面に遷移する (2547 ms)
    ✓ 仮登録完了画面から、TOP画面に遷移する (2284 ms)
    ✓ メールキャッチャーにアクセスし、届いたメールからアカウントの有効化をする (8097 ms)
    ✓ TOP画面からログインボタンを押し、ログイン画面に遷移する (3138 ms)
    ✓ フォームに値を入力する (4386 ms)
    ✓ ログインボタンを押し、TOP画面に遷移する (3346 ms)
  ユーザーがログアウトをする
    ✓ ログアウトボタンを押し、ログアウトする (2805 ms)

 PASS  test/e2e/users/footer_link_access.spec.js (12.98 s)
  ユーザーがフッターのリンクにすべてアクセスできる
    ✓ TOP画面に遷移し、フッターからプライバシーポリシー画面に遷移する (3954 ms)
    ✓ フッターから利用規約画面に遷移する (2294 ms)
    ✓ フッターからお問い合わせ画面に遷移する (2294 ms)

 PASS  test/e2e/specialists/footer_link_access.spec.js (12.884 s)
  ケアマネージャーがフッターのリンクにすべてアクセスできる
    ✓ ログイン画面に遷移し、フッターからプライバシーポリシー画面に遷移する (3869 ms)
    ✓ フッターから利用規約画面に遷移する (2292 ms)
    ✓ フッターからお問い合わせ画面に遷移する (2288 ms)

Test Suites: 4 passed, 4 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        131.332 s
```
## テストが失敗してしまった場合
### APIにリクエストが送れない場合
- コンテナリスタート
```ruby
docker-compose restart
```
### その他
- 9000番ポートに現在接続しているものの一覧を出す
```ruby
lsof -i :9000
```
- 接続しているものがあれば、このように表示される(PIDは人によって変わります)
```ruby
COMMAND  PID            (略)
node     0123 hogehoge  (略) 
```
- 接続を切る
```ruby
kill -QUIT <PID>
```
- 再度テストを実行
```ruby
yarn test:e2e
```
[【Nuxt.js】サーバ起動時にAddress already in use と表示されたときの対処](https://qiita.com/hiroyukiwk/items/57939f950aa5562bbf1c)

### 確認書類
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)
