### PR TITLE
モーダルの実装方法の統一

### DIFF
--- a/pages/specialists/office/_office_id/appointments.vue
+++ b/pages/specialists/office/_office_id/appointments.vue
@@ -61,15 +61,49 @@
                 block
                 class="mt-3 mb-2"
                 color="warning"
-                @click="call(appointment.id)"
+                @click="openCallModal(appointment.id)"
                 >連絡済みにする</v-btn
               >
-              <v-btn block color="error" @click="cancel(appointment.id)"
+              <v-btn
+                block
+                color="error"
+                @click="openCancelModal(appointment.id)"
                 >キャンセルする</v-btn
               >
             </div>
           </v-col>
         </v-card>
+        <Modal v-if="modalFlag">
+          <v-col class="mb-4 text-center">{{ modalMsg }}</v-col>
+          <div class="text-center">
+            <v-btn
+              width="120"
+              color="warning"
+              depressed
+              class="ml-2 mr-4"
+              @click="closeModal"
+              >キャンセル</v-btn
+            >
+            <v-btn
+              v-if="callMethod === 'call'"
+              id="call"
+              width="120"
+              depressed
+              outlined
+              @click="call(currentAppointmentId)"
+              ><div class="delete-button">OK</div></v-btn
+            >
+            <v-btn
+              v-else
+              id="cancel"
+              width="120"
+              depressed
+              outlined
+              @click="cancel(currentAppointmentId)"
+              ><div class="delete-button">OK</div></v-btn
+            >
+          </div>
+        </Modal>
       </v-col>
       <v-col v-show="isShow">予約はありません</v-col>
     </v-row>
@@ -96,6 +130,10 @@ export default {
       count: 0,
       page: Number(this.$route.query.page) || 1,
       offsetPage: 0,
+      callMethod: '',
+      modalFlag: false,
+      modalMsg: '',
+      currentAppointmentId: 0,
     }
   },
   watch: {
@@ -136,6 +174,22 @@ export default {
       } catch (error) {
         return error
       }
+    },
+    openCallModal(id) {
+      this.currentAppointmentId = id
+      this.modalMsg = '連絡済みにしますか？'
+      this.callMethod = 'call'
+      this.modalFlag = true
+    },
+    openCancelModal(id) {
+      this.currentAppointmentId = id
+      this.modalMsg = '本当にキャンセルしてもよろしいですか？'
+      this.callMethod = 'cancel'
+      this.modalFlag = true
+    },
+    closeModal() {
+      this.callMethod = ''
+      this.modalFlag = false
     },
     async getAppointmentsStatus() {
       if (this.page > 1) {
@@ -183,47 +237,53 @@ export default {
       }
     },
     async call(id) {
-      const isCalled = '連絡済みにしますか？'
-      if (window.confirm(isCalled)) {
-        try {
-          await this.$axios.$put(
-            `specialists/offices/${this.office_id}/appointments/${id}`,
-            {
-              called_status: 1,
-            }
-          )
-          window.location.reload()
-        } catch (error) {
-          return error
-        }
+      this.modalFlag = false
+      try {
+        await this.$axios.$put(
+          `specialists/offices/${this.office_id}/appointments/${id}`,
+          {
+            called_status: 1,
+          }
+        )
+        window.location.reload()
+      } catch (error) {
+        return error
       }
     },
     async cancel(id) {
-      const isCanceled = '本当にキャンセルしてもよろしいですか？'
-      if (window.confirm(isCanceled)) {
-        try {
-          await this.$axios.$put(
-            `specialists/offices/${this.office_id}/appointments/${id}`,
-            {
-              called_status: 2,
-            }
-          )
-          window.location.reload()
-        } catch (error) {
-          return error
-        }
+      this.modalFlag = false
+      try {
+        await this.$axios.$put(
+          `specialists/offices/${this.office_id}/appointments/${id}`,
+          {
+            called_status: 2,
+          }
+        )
+        window.location.reload()
+      } catch (error) {
+        return error
       }
     },
   },
 }
 </script>
-<style scoped>
+<style lang="scss" scoped>
 .font-color-gray {
   color: #6d7570;
 }
 
 .font-color-orange {
   color: #ff773e;
+}
+
+.delete-button {
+  color: #ff9800;
+}
+
+.modal {
+  &__overlay {
+    background: rgba(0, 0, 0, 0.1);
+  }
 }
 
 /* stylelint-disable */

--- a/pages/specialists/office/_office_id/care-recipients/index.vue
+++ b/pages/specialists/office/_office_id/care-recipients/index.vue
@@ -47,7 +47,7 @@
                 depressed
                 outlined
                 color="blue-grey lighten-4"
-                @click="deleteCareRecipients(care_recipient.id)"
+                @click="openModal(care_recipient.id)"
                 ><div class="delete-button font-weight-bold">削除</div></v-btn
               >
             </v-col>
@@ -60,17 +60,31 @@
                 class="font-weight-bold"
                 >編集する</v-btn
               >
-              <v-col
-                v-for="(staff, index) in staffs"
-                :key="index"
-                cols="12"
-                md="6"
-              >
+              <v-col v-for="(staff, i) in staffs" :key="i" cols="12" md="6">
                 {{ staff.name }}
               </v-col>
             </v-col>
           </v-row>
         </v-card>
+        <Modal v-if="modalFlag">
+          <v-col class="mb-4">本当に削除してもよろしいですか？</v-col>
+          <v-btn
+            width="120"
+            color="warning"
+            depressed
+            class="ml-2 mr-4"
+            @click="closeModal"
+            >キャンセル</v-btn
+          >
+          <v-btn
+            id="delete"
+            width="120"
+            depressed
+            outlined
+            @click="deleteCareRecipients(currentCareRecipientId)"
+            ><div class="delete-button">OK</div></v-btn
+          >
+        </Modal>
       </v-col>
     </v-row>
     <v-btn
@@ -99,6 +113,8 @@ export default {
       staffs: [],
       office: [],
       office_id: this.$route.params.office_id,
+      currentCareRecipientId: 0,
+      modalFlag: false,
     }
   },
   computed: {
@@ -110,7 +126,6 @@ export default {
   mounted() {
     this.getCareRecipients()
     this.getOffice()
-    // this.getStaffs()
   },
   methods: {
     async getOffice() {
@@ -129,7 +144,6 @@ export default {
     },
     async getCareRecipients() {
       try {
-        // this.$setId(this.office_id)
         const response = await this.$axios.$get(
           `specialists/offices/${this.office_id}/care_recipients`
         )
@@ -138,27 +152,21 @@ export default {
         return error
       }
     },
-    //  async getStaffs() {
-    //   try {
-    //     const response = await this.$axios.$get(
-    //       `specialists/offices/${this.office_id}/staffs`
-    //     )
-    //     this.staffs = response
-    //   } catch (error) {
-    //     return error
-    //   }
-    // },
+    openModal(id) {
+      this.currentCareRecipientId = id
+      this.modalFlag = true
+    },
+    closeModal() {
+      this.modalFlag = false
+    },
     async deleteCareRecipients(id) {
-      const isDeleted = '本当に削除してもよろしいですか？'
-      if (window.confirm(isDeleted)) {
-        try {
-          await this.$axios.$delete(
-            `specialists/offices/${this.office_id}/care_recipients/${id}`
-          )
-          window.location.reload()
-        } catch (error) {
-          return error
-        }
+      try {
+        await this.$axios.$delete(
+          `specialists/offices/${this.office_id}/care_recipients/${id}`
+        )
+        window.location.reload()
+      } catch (error) {
+        return error
       }
     },
   },
@@ -189,5 +197,11 @@ export default {
 
 .delete-button {
   color: #ff9800;
+}
+
+.modal {
+  &__overlay {
+    background: rgba(0, 0, 0, 0.5);
+  }
 }
 </style>

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -28,7 +28,12 @@
           </v-row>
           <v-row>
             <v-col cols="4" class="pl-6 pr-0">
-              <v-btn id="modal" block depressed outlined @click="openModal"
+              <v-btn
+                id="modal"
+                block
+                depressed
+                outlined
+                @click="openModal(staff.id)"
                 ><div class="delete-button">削除</div></v-btn
               >
             </v-col>
@@ -59,7 +64,7 @@
             width="120"
             depressed
             outlined
-            @click="deleteStaff(staff.id)"
+            @click="deleteStaff(currentStaffId)"
             ><div class="delete-button">OK</div></v-btn
           >
         </Modal>
@@ -91,6 +96,7 @@ export default {
       office_id: this.$route.params.office_id,
       office: [],
       modalFlag: false,
+      currentStaffId: 0,
     }
   },
   mounted() {
@@ -110,7 +116,8 @@ export default {
         return error
       }
     },
-    openModal() {
+    openModal(id) {
+      this.currentStaffId = id
       this.modalFlag = true
     },
     closeModal() {


### PR DESCRIPTION
## やったこと

- モーダルの実装方法・レイアウトの統一
  - スタッフ削除
  - 予約の連絡済み・キャンセル済み
  - 利用者の削除

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/unify-the-modal
```

### 動作確認 Loom 手順

- ケアマネでログイン
```ruby
specialist3@example.com
```
```ruby
password
```
- 機能確認
  - 利用者の削除ができるか
  - 予約の連絡済み・キャンセル済みができるか
- レイアウト確認
  - スタッフ・利用者・予約状況確認でモーダルのレイアウトが統一されているか
