### PR TITLE
ルーティング変更に伴いテスト修正

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -21,6 +21,6 @@ module.exports = {
   server: {
     command: 'yarn testServer',
     port: 8000,
-    launchTimeout: 150000,
+    launchTimeout: 50000,
   },
 }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -21,6 +21,6 @@ module.exports = {
   server: {
     command: 'yarn testServer',
     port: 8000,
-    launchTimeout: 50000,
+    launchTimeout: 150000,
   },
 }

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -220,7 +220,7 @@ export default {
     ...mapActions('catchErrorMsg', ['clearMsg']),
     async sign_up() {
       try {
-        const response = await this.$axios.$post(`users`, {
+        const response = await this.$axios.$post(`customer`, {
           name: this.form.name,
           email: this.form.email,
           password: this.form.password,

--- a/test/e2e/specialists/A_signup_to_login.spec.js
+++ b/test/e2e/specialists/A_signup_to_login.spec.js
@@ -109,7 +109,10 @@ describe('ケアマネージャーが新規登録してログインできる', (
     await expect(bodyText).toContain(email)
     await expect(bodyText).toContain('スペシャリスト')
     await expect(bodyText).toContain('アカウントを有効化する')
-    await page.click('a[href^="http://localhost:3000/api/users/confirmation?"]')
+    // await page.click('a[href^="http://localhost:3000/api/users/confirmation?"]')
+    await page.click(
+      'a[href^="http://localhost:3000/api/specialists/users/confirmation?"]'
+    )
 
     url = await page.mainFrame().url()
     ele = await page.$('h6')

--- a/test/e2e/users/A_signup_to_login.spec.js
+++ b/test/e2e/users/A_signup_to_login.spec.js
@@ -99,7 +99,10 @@ describe('ユーザーが新規登録してログインできる', () => {
     await expect(bodyText).toContain(email)
     await expect(bodyText).toContain('カスタマー')
     await expect(bodyText).toContain('アカウントを有効化する')
-    await page.click('a[href^="http://localhost:3000/api/users/confirmation?"]')
+    // await page.click('a[href^="http://localhost:3000/api/users/confirmation?"]')
+    await page.click(
+      'a[href^="http://localhost:3000/api/customer/confirmation"]'
+    )
 
     url = await page.mainFrame().url()
     text = await page.evaluate(() => document.body.textContent)


### PR DESCRIPTION
## やったこと

1. 新規登録パス修正
2. テストコードapiに合わせる形で一部変更 

## やらないこと

- なし

## できるようになること（ユーザ目線）

- ルーティング変更して失敗するテストのパッチプログラム テストが突破する

## できなくなること（ユーザ目線）

- なし

## 動作確認手順
- api側のセットアップが完了していること
https://github.com/koki-takishita/home-care-navi-api/pull/81

- fetch and checkout
```ruby
git fetch && git checkout origin/fix/change-users-path
```
- テストが成功することを確認する
```ruby
yarn test:e2e
```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
