### PR TITLE
お礼作成機能

### DIFF
--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -1,9 +1,42 @@
 <template>
   <v-card class="mt-6" tile height="599">
-    <v-card-title> スタッフ紹介 </v-card-title>
+    <v-card id="staff-card" outlined class="d-flex justify-space-between pa-4">
+      <v-card-title class="pa-0 font-weight-black">スタッフ紹介</v-card-title>
+      <ThankBackLink
+        class="my-auto"
+        :object="ReadOffice"
+        :text="linkText"
+        @movePage="moveThankNewPage"
+      />
+    </v-card>
   </v-card>
 </template>
 
 <script>
-export default {}
+export default {
+  props: {
+    office: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    ReadOffice() {
+      return this.office
+    },
+    linkText() {
+      return 'お礼を投稿する'
+    },
+  },
+  methods: {
+    moveThankNewPage() {
+      this.$router.push(`/offices/${this.ReadOffice.id}/thanks/new`)
+    },
+  },
+}
 </script>
+<style scoped>
+#staff-card {
+  border: 0;
+}
+</style>

--- a/components/thank/backLink.vue
+++ b/components/thank/backLink.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-card
+    id="back-link"
+    outlined
+    class="text-decoration-none"
+    @click.native="backPage"
+  >
+    <v-icon size="20" :color="linkColor">mdi-chevron-left</v-icon>
+    <font size="2" :color="linkColor">{{ backText }}</font>
+  </v-card>
+</template>
+<script>
+export default {
+  props: {
+    object: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    id() {
+      return this.object.id
+    },
+    backText() {
+      return `${this.object.name} にもどる`
+    },
+    linkColor() {
+      return '#F06364'
+    },
+  },
+  methods: {
+    backPage() {
+      this.$router.push(`/offices/${this.id}`)
+    },
+  },
+}
+</script>
+<style scoped>
+#back-link {
+  background: none;
+  cursor: pointer;
+  border: 0;
+}
+</style>

--- a/components/thank/backLink.vue
+++ b/components/thank/backLink.vue
@@ -3,10 +3,12 @@
     id="back-link"
     outlined
     class="text-decoration-none"
-    @click.native="backPage"
+    @click.native="movePage"
   >
-    <v-icon size="20" :color="linkColor">mdi-chevron-left</v-icon>
-    <font size="2" :color="linkColor">{{ backText }}</font>
+    <v-icon v-if="iconFlag" size="20" :color="linkColor"
+      >mdi-chevron-left</v-icon
+    >
+    <font size="2" :color="linkColor">{{ linkText }}</font>
   </v-card>
 </template>
 <script>
@@ -16,21 +18,32 @@ export default {
       type: Object,
       required: true,
     },
+    text: {
+      type: String,
+      required: true,
+    },
+    icon: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     id() {
       return this.object.id
     },
-    backText() {
-      return `${this.object.name} にもどる`
+    linkText() {
+      return this.text
     },
     linkColor() {
       return '#F06364'
     },
+    iconFlag() {
+      return this.icon
+    },
   },
   methods: {
-    backPage() {
-      this.$router.push(`/offices/${this.id}`)
+    movePage() {
+      this.$emit('movePage')
     },
   },
 }

--- a/components/thank/confirm.vue
+++ b/components/thank/confirm.vue
@@ -18,7 +18,15 @@
     <div class="px-4 mb-8">
       <label class="font-color-gray text-subtitle-2">
         <font :color="labelColor" class="font-weight-black">お礼の内容</font>
-        <p class="ma-0 mt-2 font-weight-light" v-html="replaceComment"></p>
+        <v-textarea
+          :value="ReadComment"
+          hide-details
+          outlined
+          readonly
+          class="font-weight-light mt-2"
+          auto-grow
+        >
+        </v-textarea>
       </label>
     </div>
     <div class="px-4">
@@ -93,4 +101,10 @@ export default {
 .link-color {
   cursor: pointer;
 }
+
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border: 0;
+}
+/* stylelint-enable */
 </style>

--- a/components/thank/confirm.vue
+++ b/components/thank/confirm.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-card class="pb-8">
+    <v-card-title class="pb-0 font-weight-black">お礼の投稿</v-card-title>
+    <p class="px-4 mt-6 mb-0 font-weight-black">
+      <font :color="labelColor" size="2">事業所名</font>
+    </p>
+    <v-card-text class="text-subtitle-1 pt-2"
+      ><font color="Black">{{ ReadOffice.name }}</font></v-card-text
+    >
+    <div class="px-4">
+      <label class="font-color-gray font-weight-black text-subtitle-2">
+        <font :color="labelColor">お礼をするスタッフ</font>
+        <p class="font-weight-light mt-2">
+          <font size="3">{{ ReadSelectedStaff.name }}</font>
+        </p>
+      </label>
+    </div>
+    <div class="px-4 mb-8">
+      <label class="font-color-gray text-subtitle-2">
+        <font :color="labelColor" class="font-weight-black">お礼の内容</font>
+        <p class="ma-0 mt-2 font-weight-light" v-html="replaceComment"></p>
+      </label>
+    </div>
+    <div class="px-4">
+      <v-btn
+        block
+        depressed
+        height="60"
+        color="error"
+        class="font-weight-black"
+        @click="clickCreateThank"
+        ><font size="4">お礼を投稿する</font>
+      </v-btn>
+    </div>
+    <p class="mt-1 mb-0 text-center" @click="backPage">
+      <font :color="linkColor" class="link-color" size="2">もどる</font>
+    </p>
+  </v-card>
+</template>
+<script>
+export default {
+  props: {
+    office: {
+      type: Object,
+      default: null,
+    },
+    staff: {
+      type: Object,
+      default: null,
+    },
+    comment: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    ReadOffice() {
+      return this.office
+    },
+    ReadSelectedStaff() {
+      return this.staff
+    },
+    ReadComment() {
+      return this.comment
+    },
+    replaceComment() {
+      const str = String(this.ReadComment)
+      const res = str.replace(/\r?\n/g, '<br>')
+      return res
+    },
+    labelColor() {
+      return '#6D7570'
+    },
+    linkColor() {
+      return '#F06364'
+    },
+  },
+  methods: {
+    clickCreateThank() {
+      this.$emit('createThank')
+    },
+    backPage() {
+      const obj = {}
+      obj.step = 1
+      obj.staff = this.ReadSelectedStaff
+      obj.comment = this.ReadComment
+      this.$emit('moveConfirmPage', obj)
+    },
+  },
+}
+</script>
+<style scoped>
+.link-color {
+  cursor: pointer;
+}
+</style>

--- a/components/thank/new.vue
+++ b/components/thank/new.vue
@@ -1,0 +1,130 @@
+<template>
+  <v-card class="pb-6">
+    <v-card-title class="pb-0 font-weight-black">お礼の投稿</v-card-title>
+    <p class="px-4 mt-6 mb-0 font-weight-black">
+      <font :color="labelColor" size="2">事業所名</font>
+    </p>
+    <v-card-text class="text-subtitle-1 pt-2"
+      ><font color="Black">{{ ReadOffice.name }}</font></v-card-text
+    >
+    <v-form ref="form" v-model="valid">
+      <div class="px-4">
+        <label class="font-color-gray font-weight-black text-subtitle-2">
+          <font :color="labelColor">お礼をするスタッフ</font>
+          <v-select
+            v-model="SelectedStaff"
+            :rules="[formValidates.objRequired]"
+            return-object
+            class="mt-2 font-weight-regular"
+            :items="ReadStaffs"
+            item-text="name"
+            item-value="id"
+            outlined
+            dense
+            placeholder="選択してください"
+          ></v-select>
+        </label>
+      </div>
+      <div class="px-4">
+        <label class="font-color-gray font-weight-black text-subtitle-2">
+          <font :color="labelColor">お礼の内容</font>
+          <v-textarea
+            v-model="Comment"
+            :rules="[formValidates.required]"
+            class="font-weight-light mt-2"
+            height="140"
+            placeholder="入力してください"
+            outlined
+          >
+          </v-textarea>
+        </label>
+      </div>
+    </v-form>
+    <div class="px-4">
+      <v-btn
+        :disabled="!valid"
+        block
+        depressed
+        height="60"
+        color="error"
+        class="font-weight-black"
+        @click="clickConfirmBtn"
+        ><font size="4">確認へ進む</font>
+      </v-btn>
+    </div>
+  </v-card>
+</template>
+<script>
+export default {
+  props: {
+    office: {
+      type: Object,
+      required: true,
+    },
+    staffs: {
+      type: Array,
+      default: null,
+    },
+    selectedStaff: {
+      type: Object,
+      default: null,
+    },
+    comment: {
+      type: String,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        objRequired: (value) => !!value.id || '必須項目です',
+      },
+      valid: false,
+    }
+  },
+  computed: {
+    ReadOffice() {
+      return this.office
+    },
+    ReadStaffs() {
+      return this.staffs
+    },
+    SelectedStaff: {
+      get() {
+        return this.selectedStaff
+      },
+      set(SelectedStaff) {
+        this.$emit('update:selectedStaff', SelectedStaff)
+      },
+    },
+    Comment: {
+      get() {
+        return this.comment
+      },
+      set(Comment) {
+        this.$emit('update:comment', Comment)
+      },
+    },
+    labelColor() {
+      return '#6D7570'
+    },
+  },
+  methods: {
+    clickConfirmBtn() {
+      const obj = {}
+      obj.step = 2
+      obj.staff = this.SelectedStaff
+      obj.comment = this.Comment
+      this.$emit('moveConfirmPage', obj)
+    },
+  },
+}
+</script>
+<style scoped>
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+/* stylelint-enable */
+</style>

--- a/components/thank/success.vue
+++ b/components/thank/success.vue
@@ -6,7 +6,12 @@
     <v-card-text class="mt-12 text-center">
       お礼の投稿が完了しました。<br />
       投稿いただきありがとうございました。
-      <ThankBackLink class="mt-8 mb-4" :object="office" />
+      <ThankBackLink
+        class="mt-8 mb-4"
+        :object="office"
+        :text="linkText"
+        @movePage="backPage"
+      />
     </v-card-text>
   </v-card>
 </template>
@@ -22,11 +27,19 @@ export default {
     labelColor() {
       return '#6D7570'
     },
+    linkText() {
+      return `${this.office.name}に戻る`
+    },
     linkColor() {
       return '#F06364'
     },
     office() {
       return this.object
+    },
+  },
+  methods: {
+    backPage() {
+      this.$router.push(`/offices/${this.office.id}`)
     },
   },
 }

--- a/components/thank/success.vue
+++ b/components/thank/success.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-card class="pb-8">
+    <v-card-title class="pb-0 pt-8 font-weight-black justify-center"
+      >お礼の投稿完了</v-card-title
+    >
+    <v-card-text class="mt-12 text-center">
+      お礼の投稿が完了しました。<br />
+      投稿いただきありがとうございました。
+      <ThankBackLink class="mt-8 mb-4" :object="office" />
+    </v-card-text>
+  </v-card>
+</template>
+<script>
+export default {
+  props: {
+    object: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    labelColor() {
+      return '#6D7570'
+    },
+    linkColor() {
+      return '#F06364'
+    },
+    office() {
+      return this.object
+    },
+  },
+}
+</script>

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -9,7 +9,7 @@
           :staffs="office.staffs"
         />
         <office-detail-card :office="office.office" />
-        <office-staff-card />
+        <office-staff-card :office="office.office" />
       </v-col>
       <v-col cols="12" sm="12" md="6">
         <office-data-card-pc

--- a/pages/offices/_id/thanks/new.vue
+++ b/pages/offices/_id/thanks/new.vue
@@ -1,0 +1,108 @@
+<template>
+  <v-stepper v-model="step" class="mb-4 mx-auto" max-width="750" outlined>
+    <v-stepper-items>
+      <v-stepper-content step="1" class="pa-0">
+        <ThankBackLink class="mt-8 mb-4" :object="office" />
+        <ThankNew
+          :office="office"
+          :staffs="staffs"
+          :selected-staff.sync="selectedStaff"
+          :comment.sync="comment"
+          @moveConfirmPage="changeStep"
+        />
+      </v-stepper-content>
+      <v-stepper-content step="2" class="pa-0">
+        <ThankBackLink class="mt-8 mb-4" :object="office" />
+        <ThankConfirm
+          :office="office"
+          :staff="selectedStaff"
+          :comment="comment"
+          @moveConfirmPage="changeStep"
+          @createThank="createThank"
+        />
+      </v-stepper-content>
+      <v-stepper-content step="3">
+        <ThankSuccess :object="office" />
+      </v-stepper-content>
+    </v-stepper-items>
+  </v-stepper>
+</template>
+<script>
+export default {
+  layout: 'application',
+  async asyncData({ params, $axios, query }) {
+    const currentStep = query.step
+    const officeId = params.id
+    const selectedStaff = JSON.parse(query.staff || '{}')
+    const comment = query.comment || ''
+    try {
+      const res = await $axios.$get(`offices/${officeId}`)
+      return {
+        office: res.office,
+        staffs: res.staffs,
+        step: currentStep,
+        selectedStaff,
+        comment,
+      }
+    } catch (error) {
+      return error
+    }
+  },
+  data() {
+    return {
+      step: 1,
+      office: {},
+      staffs: [],
+      selectedStaff: {},
+      comment: '',
+    }
+  },
+  methods: {
+    changeStep(obj) {
+      const staff = JSON.stringify(obj.staff) || '{}'
+      const comment = obj.comment || ''
+      const step = obj.step
+      this.step = step
+      this.$router.push({
+        path: `/offices/${this.office.id}/thanks/new`,
+        query: {
+          step,
+          staff,
+          comment,
+        },
+      })
+    },
+    async createThank() {
+      try {
+        const thankParameter = {}
+        thankParameter.staff_id = this.selectedStaff.id
+        thankParameter.office_id = this.office.id
+        thankParameter.comments = this.comment
+        await this.$axios.$post(`offices/${this.office.id}/thanks`, {
+          thank: thankParameter,
+        })
+        this.step = 3
+        this.$router.push({
+          path: `/offices/${this.office.id}/thanks/new`,
+          query: {
+            step: this.step,
+          },
+        })
+      } catch (error) {
+        const msg = error.response.data.message
+        this.$store.commit('catchErrorMsg/setType', 'error')
+        this.$store.commit('catchErrorMsg/setMsg', [msg])
+        return error
+      }
+    },
+  },
+}
+</script>
+<style scoped>
+/* stylelint-disable */
+.v-stepper.mb-4.mx-auto.v-sheet.v-sheet--outlined.theme--light {
+  border: 0px;
+  background: none;
+}
+/* stylelint-enable */
+</style>

--- a/pages/offices/_id/thanks/new.vue
+++ b/pages/offices/_id/thanks/new.vue
@@ -2,7 +2,13 @@
   <v-stepper v-model="step" class="mb-4 mx-auto" max-width="750" outlined>
     <v-stepper-items>
       <v-stepper-content step="1" class="pa-0">
-        <ThankBackLink class="mt-8 mb-4" :object="office" />
+        <ThankBackLink
+          class="mt-8 mb-4"
+          :object="office"
+          :text="linkText"
+          icon
+          @movePage="backPage"
+        />
         <ThankNew
           :office="office"
           :staffs="staffs"
@@ -12,7 +18,13 @@
         />
       </v-stepper-content>
       <v-stepper-content step="2" class="pa-0">
-        <ThankBackLink class="mt-8 mb-4" :object="office" />
+        <ThankBackLink
+          class="mt-8 mb-4"
+          :object="office"
+          :text="linkText"
+          icon
+          @movePage="backPage"
+        />
         <ThankConfirm
           :office="office"
           :staff="selectedStaff"
@@ -57,7 +69,15 @@ export default {
       comment: '',
     }
   },
+  computed: {
+    linkText() {
+      return `${this.office.name}に戻る`
+    },
+  },
   methods: {
+    backPage() {
+      this.$router.push(`/offices/${this.office.id}`)
+    },
     changeStep(obj) {
       const staff = JSON.stringify(obj.staff) || '{}'
       const comment = obj.comment || ''


### PR DESCRIPTION
## やったこと

1. お礼作成ページ作成
2. コンポーネント作成
   - 新規フォーム用
   - 確認ページ用
   - 作成完了ページ用

## やらないこと
いろいろやることが増えてきて後で増える可能性も鑑みて、後回し(キリが無くなってきた) 今週中には対応
1. バリテーション(120文字以下)
2. お礼作成ページに行く前にログインしていなかったらブロック
3. 確認ページのコメント確認フォームpaddingなくす
4. フラッシュメッセージ失敗した時は表示されるように バグ出てる(フラッシュは作り直すのでここでやると終わらん)
5. スマホサイズだと上部の戻るリンクがなくなる

## できるようになること（ユーザ目線）

1. お礼を作成できる

## できなくなること（ユーザ目線）

なし

### API 側
- fetch and checkout api側と一緒に確認する
https://github.com/koki-takishita/home-care-navi-api/pull/83
```ruby
git fetch && git checkout origin/feature/create-thank
```

### Front 側
- fetch and checkout

```ruby
git fetch && git checkout origin/feature/thanks-new-page
```

### 動作確認 Loom 手順
テストが問題ないか確認
```ruby
docker-compose exec web bundle exec rspec spec/requests/api/customer/thanks_spec.rb
```
Customerのseed実行
```ruby
docker-compose exec web rails db:seed:dummy_customer
```
- email
```ruby
mawatari_ayako@example.net
```
- password
```ruby
password
```
- お礼増えていること確認する手順
```ruby
docker-compose exec web rails c

# 自分の入力した情報が格納されていること確認
Thank.last
```
1. ログインする
2. サンプルで検索かける
3. お礼を投稿ボタンを押す
4. スタッフ選択
5. お礼フォーム入力
6. 確認
7. お礼投稿ボタン押す
8. お礼が増えていることをコンソール上で確認する
-  [Loom お礼作成手順](https://www.loom.com/share/581c1b4bc2804bdb8af7dc773f4a2986)

### 確認書類
[お礼作成画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/c1c92180-e752-4c99-bc75-5db4580c1ed4/specs/)
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
ほかに見落としあればコメントください
