### PR TITLE
スタッフ一覧・利用者一覧画面　ソート＆ページネーション

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -62,7 +62,9 @@
                                 事業所情報編集</v-list-item-title
                               >
                             </v-list-item>
-                            <v-list-item to="/specialists/office/1/staffs">
+                            <v-list-item
+                              to="/specialists/office/1/staffs?page=1"
+                            >
                               <v-list-item-title
                                 class="header-style text-overline text-decoration-none mr-5"
                               >
@@ -86,7 +88,7 @@
                               </v-list-item-title>
                             </v-list-item>
                             <v-list-item
-                              to="/specialists/office/1/care-recipients"
+                              to="/specialists/office/1/care-recipients?page=1"
                             >
                               <v-list-item-title
                                 class="header-style text-overline text-decoration-none mr-5"
@@ -290,7 +292,7 @@
               <v-divider color="#D9DEDE"></v-divider>
               <v-list-item
                 class="pa-0 ma-0 px-6 py-4 min-height-20"
-                to="/specialists/office/1/staffs"
+                to="/specialists/office/1/staffs?page=1"
               >
                 <v-list-item-title
                   class="text-decoration-none text-body-2 navi-style"
@@ -329,7 +331,7 @@
               <v-divider color="#D9DEDE"></v-divider>
               <v-list-item
                 class="pa-0 ma-0 px-6 py-4 min-height-20"
-                to="/specialists/office/1/care-recipients"
+                to="/specialists/office/1/care-recipients?page=1"
               >
                 <v-list-item-title
                   class="text-decoration-none text-body-2 navi-style"

--- a/pages/specialists/office/_office_id/appointments.vue
+++ b/pages/specialists/office/_office_id/appointments.vue
@@ -288,11 +288,11 @@ export default {
 
 /* stylelint-disable */
 ::v-deep .v-pagination i.v-icon.notranslate.mdi.mdi-chevron-left.theme--light {
-  color: #f06364;
+  color: #ff9800;
 }
 
 ::v-deep .v-pagination i.v-icon.notranslate.mdi.mdi-chevron-right.theme--light {
-  color: #f06364;
+  color: #ff9800;
 }
 
 .pa-2.remove-bottom-border-radius.v-card.v-sheet.v-sheet--outlined.theme--light.rounded-0 {

--- a/pages/specialists/office/_office_id/care-recipients/_care_recipient_id/edit.vue
+++ b/pages/specialists/office/_office_id/care-recipients/_care_recipient_id/edit.vue
@@ -149,7 +149,7 @@
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to=".."
+              to="..?page=1"
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >
@@ -287,7 +287,7 @@ export default {
         const response = await this.$axios.$get(
           `specialists/offices/${this.office_id}/staffs`
         )
-        this.staffs = response
+        this.staffs = response.staffs
       } catch (error) {
         return error
       }

--- a/pages/specialists/office/_office_id/care-recipients/new.vue
+++ b/pages/specialists/office/_office_id/care-recipients/new.vue
@@ -146,7 +146,7 @@
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to="."
+              to=".?page=1"
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >

--- a/pages/specialists/office/_office_id/care-recipients/new.vue
+++ b/pages/specialists/office/_office_id/care-recipients/new.vue
@@ -269,7 +269,7 @@ export default {
         const response = await this.$axios.$get(
           `specialists/offices/${this.office_id}/staffs`
         )
-        this.staffs = response
+        this.staffs = response.staffs
       } catch (error) {
         return error
       }

--- a/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
@@ -82,7 +82,7 @@
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to="....?page=1"
+              to="..?page=1"
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >

--- a/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
@@ -160,7 +160,7 @@ export default {
             headers: { 'Content-Type': 'multipart/form-data' },
           }
         )
-        this.$router.push('..')
+        this.$router.push('..?page=1')
       } catch (error) {
         return error
       }

--- a/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/_office_id/staffs/_staff_id/edit.vue
@@ -82,7 +82,7 @@
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to=".."
+              to="....?page=1"
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >

--- a/pages/specialists/office/_office_id/staffs/index.vue
+++ b/pages/specialists/office/_office_id/staffs/index.vue
@@ -83,6 +83,14 @@
         スタッフを追加する
       </div>
     </v-btn>
+    <div class="mt-2 text-center">
+      <v-pagination
+        v-model="page"
+        :length="count"
+        color="#D9DEDE"
+        class="page-nation"
+      ></v-pagination>
+    </div>
   </v-col>
 </template>
 
@@ -95,11 +103,34 @@ export default {
       staffs: [],
       office_id: this.$route.params.office_id,
       office: [],
+      count: 0,
+      page: Number(this.$route.query.page) || 1,
+      offsetPage: 0,
       modalFlag: false,
       currentStaffId: 0,
     }
   },
+  watch: {
+    page() {
+      this.$router.push({
+        path: `/specialists/office/${this.office_id}/staffs`,
+        query: {
+          page: this.page,
+        },
+      })
+      this.scrollTop()
+    },
+  },
   mounted() {
+    this.$watch(
+      'page',
+      function () {
+        this.getStaffs()
+      },
+      {
+        immediate: true,
+      }
+    )
     this.getOffice()
     this.getStaffs()
   },
@@ -110,7 +141,7 @@ export default {
           `specialists/offices/${this.office.id}`
         )
         if (response.id - this.office_id !== 0) {
-          this.$router.push(`/specialists/office/${response.id}/staffs`)
+          this.$router.push(`/specialists/office/${response.id}/staffs?page=1`)
         }
       } catch (error) {
         return error
@@ -124,14 +155,28 @@ export default {
       this.modalFlag = false
     },
     async getStaffs() {
+      if (this.page > 1) {
+        this.offsetPage = this.page - 1
+      } else {
+        this.offsetPage = 0
+      }
       try {
         const response = await this.$axios.$get(
-          `specialists/offices/${this.office_id}/staffs`
+          `specialists/offices/${this.office_id}/staffs?page=${this.offsetPage}`
         )
-        this.staffs = response
+        this.staffs = response.staffs
+        this.count = response.data_length
+        this.count = this.count / 10
+        this.count = Math.ceil(this.count)
+        if (this.count === 0) {
+          this.count = 1
+        }
       } catch (error) {
         return error
       }
+    },
+    scrollTop() {
+      this.$vuetify.goTo(0)
     },
     async deleteStaff(id) {
       this.modalFlag = false
@@ -173,4 +218,30 @@ export default {
 .delete-button {
   color: #ff9800;
 }
+
+/* stylelint-disable */
+::v-deep .v-pagination i.v-icon.notranslate.mdi.mdi-chevron-left.theme--light {
+  color: #ff9800;
+}
+
+::v-deep .v-pagination i.v-icon.notranslate.mdi.mdi-chevron-right.theme--light {
+  color: #ff9800;
+}
+
+.pa-2.remove-bottom-border-radius.v-card.v-sheet.v-sheet--outlined.theme--light.rounded-0 {
+  border: 0;
+}
+
+::v-deep button.v-pagination__navigation.v-pagination__navigation {
+  box-shadow: none;
+}
+
+::v-deep button.v-pagination__item {
+  box-shadow: none;
+}
+
+::v-deep button.v-pagination__item.v-pagination__item--active {
+  box-shadow: none;
+}
+/* stylelint-enable */
 </style>

--- a/pages/specialists/office/_office_id/staffs/new.vue
+++ b/pages/specialists/office/_office_id/staffs/new.vue
@@ -135,7 +135,7 @@ export default {
         await this.$axios.$post(`specialists/offices/${id}/staffs`, params, {
           headers: { 'Content-Type': 'multipart/form-data' },
         })
-        this.$router.push('.')
+        this.$router.push('.?page=1')
       } catch (error) {
         return error
       }

--- a/pages/specialists/office/_office_id/staffs/new.vue
+++ b/pages/specialists/office/_office_id/staffs/new.vue
@@ -80,7 +80,7 @@
           </v-btn>
           <p class="mb-0 text-center">
             <NuxtLink
-              to="."
+              to=".?page=1"
               class="text-overline text-decoration-none link-color"
               >もどる</NuxtLink
             >

--- a/test/e2e/specialists/C_create_staffs_update.spec.js
+++ b/test/e2e/specialists/C_create_staffs_update.spec.js
@@ -31,14 +31,16 @@ describe('ケアマネージャーがスタッフを登録できる', () => {
   it('ヘッダーからスタッフ登録画面に遷移する', async () => {
     await page.click('#menu')
     await page.evaluate(() => {
-      document.querySelector('a[href="/specialists/office/1/staffs"]').click()
+      document
+        .querySelector('a[href="/specialists/office/1/staffs?page=1"]')
+        .click()
     })
     await page.waitForTimeout(1000)
     url = await page.mainFrame().url()
     ele = await page.$('h3')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
     await expect(url).toContain('http://localhost:8000/specialists/office')
-    await expect(url).toContain('staffs')
+    await expect(url).toContain('staffs?page=1')
     await expect(titleText).toContain('スタッフ情報')
   })
 
@@ -75,7 +77,7 @@ describe('ケアマネージャーがスタッフを登録できる', () => {
     ele = await page.$('h3')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
     await expect(url).toContain('http://localhost:8000/specialists/office')
-    await expect(url).toContain('staffs')
+    await expect(url).toContain('staffs?page=1')
     await expect(titleText).toContain('スタッフ情報')
   })
 
@@ -115,7 +117,7 @@ describe('ケアマネージャーがスタッフを登録できる', () => {
     ele = await page.$('h3')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
     await expect(url).toContain('http://localhost:8000/specialists/office')
-    await expect(url).toContain('staffs')
+    await expect(url).toContain('staffs?page=1')
     await expect(titleText).toContain('スタッフ情報')
   })
 


### PR DESCRIPTION
## やったこと

- スタッフ一覧画面と、利用者一覧画面を、更新日順に並べ、ページネーションを実装した

## やらないこと

- なし

# **必要なかったら消すこと**

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/staffs-care_recipients-index-sort
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/staffs-care_recipients-index-pagenation
```

### 動作確認 Loom 手順

- こちらのプルリクの動作確認を終わらせる
https://github.com/koki-takishita/home-care-navi-api/pull/84
- ケアマネでログインする
```ruby
specialist3@example.com
```
```ruby
password
```
- ヘッダーからスタッフ一覧画面に遷移し、ページネーションが動いてるか確認
- 編集したスタッフが先頭に来るか確認
- ヘッダーから利用者一覧画面に遷移し、ページネーションおよびCRUD機能機能の確認
- 編集した利用者が先頭に来るか確認