### PR TITLE
スタッフ紹介コンポーネント作成

### DIFF
--- a/components/office/officeDataCardPc.vue
+++ b/components/office/officeDataCardPc.vue
@@ -78,7 +78,7 @@
 export default {
   props: {
     officeId: {
-      type: String,
+      type: Number,
       default() {
         return null
       },

--- a/components/office/officeDataCardSp.vue
+++ b/components/office/officeDataCardSp.vue
@@ -72,7 +72,7 @@
 export default {
   props: {
     officeId: {
-      type: String,
+      type: Number,
       default() {
         return null
       },

--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -9,7 +9,9 @@
         @movePage="moveThankNewPage"
       />
     </v-card>
-    <StaffIntroductionCard class="pa-4 pt-0" :staffs="ReadStaffs" />
+    <template v-for="staff in ReadStaffs">
+      <StaffIntroductionCard :key="staff.id" class="pa-4 pt-0" :staff="staff" />
+    </template>
   </v-card>
 </template>
 

--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -19,10 +19,17 @@ export default {
       type: Object,
       required: true,
     },
+    staffs: {
+      type: Array,
+      default: null,
+    },
   },
   computed: {
     ReadOffice() {
       return this.office
+    },
+    ReadStaffs() {
+      return this.staffs
     },
     linkText() {
       return 'お礼を投稿する'

--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="mt-6" tile height="599">
+  <v-card class="mt-6 overflow-auto" tile max-height="600">
     <v-card id="staff-card" outlined class="d-flex justify-space-between pa-4">
       <v-card-title class="pa-0 font-weight-black">スタッフ紹介</v-card-title>
       <ThankBackLink
@@ -9,6 +9,7 @@
         @movePage="moveThankNewPage"
       />
     </v-card>
+    <StaffIntroductionCard class="pa-4 pt-0" :staffs="ReadStaffs" />
   </v-card>
 </template>
 

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-card id="staff-introduction" outlined>
+    <v-row
+      v-for="(staff, i) in ReadStaffs"
+      :key="i"
+      no-gutters
+      justify="end"
+      class="mb-4"
+    >
+      <v-col cols="3">
+        <v-avatar size="80">
+          <img :src="staff.image" />
+        </v-avatar>
+      </v-col>
+      <v-col cols="9">
+        <v-row no-gutters>
+          <v-col cols="12" sm="3">
+            <div class="">
+              <v-card-title class="pa-0 font-weight-black text-subtitle-1">
+                {{ staff.name }}
+              </v-card-title>
+              <div class="mt-n2">
+                <font size="1" :color="grayColor">{{ staff.kana }}</font>
+              </div>
+            </div>
+          </v-col>
+          <v-col cols="12" sm="9">
+            <v-card
+              id="staff-introduction"
+              class="set-line-height"
+              outlined
+              max-width="206"
+            >
+              <font size="2" :color="grayColor">{{ staff.introduction }} </font>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col
+        v-for="(comment, staff_i) in staff.thanks"
+        :key="comment.id"
+        cols="12"
+        sm="9"
+      >
+        <StaffThankCard
+          :thank="comment"
+          :index-num="staff_i"
+          :count="thanksCount(staff)"
+          :is-open="isOpen"
+          @thanksListOpen="setOpen"
+        />
+      </v-col>
+    </v-row>
+  </v-card>
+</template>
+<script>
+export default {
+  props: {
+    staffs: {
+      type: Array,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      isOpen: false,
+    }
+  },
+  computed: {
+    ReadStaffs() {
+      return this.staffs
+    },
+    grayColor() {
+      return '#6D7570'
+    },
+  },
+  methods: {
+    setOpen(boolean) {
+      this.isOpen = !boolean
+    },
+    thanksCount(obj) {
+      return obj.thanks.length
+    },
+  },
+}
+</script>
+<style scoped>
+#staff-introduction {
+  border: 0;
+}
+
+.set-line-height {
+  line-height: normal;
+}
+</style>

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -1,15 +1,9 @@
 <template>
   <v-card id="staff-introduction" outlined>
-    <v-row
-      v-for="(staff, i) in ReadStaffs"
-      :key="i"
-      no-gutters
-      justify="end"
-      class="mb-4"
-    >
+    <v-row no-gutters justify="end" class="mb-4">
       <v-col cols="3">
         <v-avatar size="80">
-          <img :src="staff.image" />
+          <img :src="ReadStaff.image" />
         </v-avatar>
       </v-col>
       <v-col cols="9">
@@ -20,7 +14,7 @@
                 {{ staff.name }}
               </v-card-title>
               <div class="mt-n2">
-                <font size="1" :color="grayColor">{{ staff.kana }}</font>
+                <font size="1" :color="grayColor">{{ ReadStaff.kana }}</font>
               </div>
             </div>
           </v-col>
@@ -31,23 +25,20 @@
               outlined
               max-width="206"
             >
-              <font size="2" :color="grayColor">{{ staff.introduction }} </font>
+              <font size="2" :color="grayColor"
+                >{{ ReadStaff.introduction }}
+              </font>
             </v-card>
           </v-col>
         </v-row>
       </v-col>
-      <v-col
-        v-for="(comment, staff_i) in staff.thanks"
-        :key="comment.id"
-        cols="12"
-        sm="9"
-      >
+      <v-col v-for="(thank, i) in ReadThanks" :key="thank.id" cols="12" sm="9">
         <StaffThankCard
-          :thank="comment"
-          :index-num="staff_i"
+          :thank="thank"
+          :index-num="i"
           :count="thanksCount(staff)"
           :is-open="isOpen"
-          @thanksListOpen="setOpen"
+          @thanksListOpen="setIsOpen"
         />
       </v-col>
     </v-row>
@@ -56,8 +47,8 @@
 <script>
 export default {
   props: {
-    staffs: {
-      type: Array,
+    staff: {
+      type: Object,
       default: null,
     },
   },
@@ -67,16 +58,19 @@ export default {
     }
   },
   computed: {
-    ReadStaffs() {
-      return this.staffs
+    ReadStaff() {
+      return this.staff
+    },
+    ReadThanks() {
+      return this.ReadStaff.thanks
     },
     grayColor() {
       return '#6D7570'
     },
   },
   methods: {
-    setOpen(boolean) {
-      this.isOpen = !boolean
+    setIsOpen(obj) {
+      this.isOpen = !obj
     },
     thanksCount(obj) {
       return obj.thanks.length

--- a/components/staff/thankCard.vue
+++ b/components/staff/thankCard.vue
@@ -45,7 +45,7 @@ export default {
     },
     isOpen: {
       type: Boolean,
-      default: false,
+      default: null,
     },
   },
   computed: {

--- a/components/staff/thankCard.vue
+++ b/components/staff/thankCard.vue
@@ -1,0 +1,109 @@
+<template>
+  <div :class="setSpaceY">
+    <p v-if="isIndexNumOne" class="ma-0 my-1 text-right" @click="toggleList">
+      {{ toggleMessage }}
+    </p>
+    <v-card
+      v-if="isIndexNumZero"
+      min-height="61"
+      tile
+      outlined
+      :color="lightGreen"
+    >
+      <v-row no-gutters>
+        <v-col cols="1" class="text-center">
+          <v-icon color="#AEB5B2">mdi-account</v-icon>
+        </v-col>
+        <v-col cols="11">
+          <v-card-title class="pa-0">
+            <p class="text-caption font-weight-black mb-0">
+              ユーザーからのお礼のコメント
+            </p>
+          </v-card-title>
+          <v-card-text class="pa-0 text-caption min-line-height">
+            <p class="mb-0">{{ ReadThank.comments }}</p>
+          </v-card-text>
+        </v-col>
+      </v-row>
+    </v-card>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    thank: {
+      type: Object,
+      default: null,
+    },
+    indexNum: {
+      type: Number,
+      default: null,
+    },
+    count: {
+      type: Number,
+      default: null,
+    },
+    isOpen: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    ReadThank() {
+      return this.thank
+    },
+    ReadIndexNum() {
+      return this.indexNum
+    },
+    ReadOpen() {
+      return this.isOpen
+    },
+    ReadCount() {
+      return this.count
+    },
+    lightGreen() {
+      return 'rgba(169, 240, 209, 16%)'
+    },
+    setSpaceY() {
+      if (this.indexNum > 0) {
+        return 'my-1'
+      } else {
+        return ''
+      }
+    },
+    toggleMessage() {
+      let msg
+      if (this.isOpen) {
+        msg = '閉じる'
+      } else {
+        msg = `ほかの${this.ReadCount - 1}件のお礼を見る`
+      }
+      return msg
+    },
+    isIndexNumOne() {
+      if (this.ReadIndexNum === 1) {
+        return true
+      } else {
+        return false
+      }
+    },
+    isIndexNumZero() {
+      if (this.ReadIndexNum === 0) {
+        return true
+      } else {
+        return this.ReadOpen
+      }
+    },
+  },
+  methods: {
+    toggleList() {
+      this.$emit('thanksListOpen', this.ReadOpen)
+    },
+  },
+}
+</script>
+<style scoped>
+.min-line-height {
+  line-height: 1.1;
+}
+</style>

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -2,38 +2,40 @@
   <v-container class="pt-10">
     <v-row>
       <v-col cols="12" sm="12" md="6">
-        <office-images-card :images="office.images" />
+        <office-images-card :images="officeImages" />
         <office-data-card-sp
-          :office-id="office_id"
-          :office="office.office"
-          :staffs="office.staffs"
+          :office-id="office.id"
+          :office="office"
+          :staffs="staffs"
         />
-        <office-detail-card :office="office.office" />
-        <office-staff-card :office="office.office" />
+        <office-detail-card :office="office" />
+        <office-staff-card :office="office" :staffs="staffs" />
       </v-col>
       <v-col cols="12" sm="12" md="6">
         <office-data-card-pc
-          :office-id="office_id"
-          :office="office.office"
-          :staffs="office.staffs"
+          :office-id="office.id"
+          :office="office"
+          :staffs="staffs"
         />
       </v-col>
     </v-row>
   </v-container>
 </template>
-
 <script>
 export default {
   layout: 'application',
   async asyncData({ $axios, params }) {
-    let officeArray = []
-    const id = `${params.id}`
-    await $axios.$get(`offices/${id}`).then((res) => (officeArray = res))
-    return { office: officeArray }
-  },
-  data() {
-    return {
-      office_id: this.$route.params.id,
+    const id = params.id
+    try {
+      const res = await $axios.$get(`offices/${id}`)
+      return {
+        office: res.office,
+        officeImages: res.officeImages,
+        staffs: res.staffs,
+      }
+    } catch (error) {
+      // console.log(error)
+      return error
     }
   },
 }


### PR DESCRIPTION
## やったこと

1. スタッフ紹介コンポーネント作成
    - スタッフ一覧が見れる
    - スタッフのお礼一覧が見れる
    - お礼が2件以上の場合は開閉ボタンで開閉できる

## やらないこと

- スタイリング
- レイアウトはpcのみ
- api側でお礼が多い順に並べる必要あり

## できるようになること（ユーザ目線）

- 事業所に在籍しているスタッフ一覧が見れる
- スタッフに寄せられたお礼一覧が見れる

## できなくなること（ユーザ目線）

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/thank-api
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/thank-achievement
```

### 動作確認 Loom 手順
- email
```ruby
kei_sawada@example.net
```
- pass
```ruby
password
```
1. ログインする
2. お礼作成する
3. 2つ以上だったら開閉できる
  [手順動画](https://www.loom.com/share/a780ddfdef6e42afa1260e6fbd24955d)


## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
