### PR TITLE
お礼をページログインしないと遷移できないように設定

### DIFF
--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -30,7 +30,13 @@ export default {
   },
   methods: {
     moveThankNewPage() {
+      this.$auth.loggedIn ? this.thankPagePath() : this.shouldLoginAlert()
+    },
+    thankPagePath() {
       this.$router.push(`/offices/${this.ReadOffice.id}/thanks/new`)
+    },
+    shouldLoginAlert() {
+      alert('お礼をするにはログインしてください')
     },
   },
 }

--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -36,7 +36,7 @@ export default {
       this.$router.push(`/offices/${this.ReadOffice.id}/thanks/new`)
     },
     shouldLoginAlert() {
-      alert('お礼をするにはログインしてください')
+      alert('ログインをする必要があります')
     },
   },
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,7 +78,7 @@ export default {
   },
   auth: {
     redirect: {
-      login: false,
+      login: '/top',
       logout: false,
       callback: false,
       home: false,

--- a/pages/offices/_id/thanks/new.vue
+++ b/pages/offices/_id/thanks/new.vue
@@ -42,7 +42,6 @@
 <script>
 export default {
   layout: 'application',
-  middleware: 'auth',
   async asyncData({ params, $axios, query }) {
     const currentStep = query.step
     const officeId = params.id

--- a/pages/offices/_id/thanks/new.vue
+++ b/pages/offices/_id/thanks/new.vue
@@ -42,6 +42,7 @@
 <script>
 export default {
   layout: 'application',
+  middleware: 'auth',
   async asyncData({ params, $axios, query }) {
     const currentStep = query.step
     const officeId = params.id


### PR DESCRIPTION
## やったこと

1. ログインしないとお礼作成ページへ遷移できないようにalert設定
2. ログインせずに、url直打ちだと強制的にtopページへ遷移

## やらないこと

強制リダイレクトの仕様はまだ定かでない
- 直うちの時点で悪質だと判断してフラッシュも何も用意してない
- alertかなにか用意したほうが良いのか

## できるようになること（ユーザ目線）

- 悪質なユーザーのブロック

## できなくなること（ユーザ目線）

- url直うちでアクセスできなくなる
- ログインしないとお礼作成ページへアクセスできなくなる

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/login-alert-move-thanks-page
```

### 動作確認 Loom 手順
動作確認用 サンプルユーザー
- email
```ruby
mawatari_ayako@example.net
```
- password
```ruby
password
```
[ログインしていないとアラート出る](https://www.loom.com/share/2a92211b093048ab9c7e9ece8a4aa257)

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
