### PR TITLE
ケアマネ・カスタマー画面ログイン制限

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   launch: {
-    headless: true,
+    headless: false,
     slowMo: 250,
     innerWidth: 1280,
     innerHeight: 800,

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   launch: {
-    headless: false,
+    headless: true,
     slowMo: 250,
     innerWidth: 1280,
     innerHeight: 800,

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -336,6 +336,7 @@
 <script>
 export default {
   layout: 'top',
+  middleware: 'authenticateCustomer',
   data() {
     return {
       logoutInfo: {

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -449,6 +449,7 @@
 <script>
 export default {
   layout: 'top',
+  middleware: 'authenticateSpecialist',
   data() {
     return {
       logoutInfo: {

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -14,7 +14,6 @@ export default function ({ store, redirect, route }) {
     route.path !== '/' &&
     store.state.customer !== 'true'
   ) {
-    console.log('ミドルウェア カスタマー')
     return redirect('/users/login')
   }
 }

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -1,0 +1,20 @@
+export default function ({ store, redirect, route }) {
+  if (
+    route.path !== '/users/login' &&
+    route.path !== '/top' &&
+    route.path !== '/offices' &&
+    route.name !== 'offices-id' &&
+    route.path !== '/users/privacy_policy' &&
+    route.path !== '/users/terms' &&
+    route.path !== '/users/contacts/new' &&
+    route.path !== '/users/contacts/confirm' &&
+    route.path !== '/users/contacts/success' &&
+    route.path !== '/users/new' &&
+    route.path !== '/users/send' &&
+    route.path !== '/' &&
+    store.state.customer !== 'true'
+  ) {
+    console.log('ミドルウェア カスタマー')
+    return redirect('/users/login')
+  }
+}

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -1,4 +1,4 @@
-export default async ({ $auth, store, redirect, route }) => {
+export default async function ({ $auth, store, redirect, route }) {
   if (
     route.path !== '/users/login' &&
     route.path !== '/top' &&
@@ -17,5 +17,4 @@ export default async ({ $auth, store, redirect, route }) => {
     await $auth.logout()
     return redirect('/users/login')
   }
-  store.commit('logoutUser')
 }

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -1,4 +1,4 @@
-export default function ({ store, redirect, route }) {
+export default async ({ $auth, store, redirect, route }) => {
   if (
     route.path !== '/users/login' &&
     route.path !== '/top' &&
@@ -14,6 +14,8 @@ export default function ({ store, redirect, route }) {
     route.path !== '/' &&
     store.state.customer !== 'true'
   ) {
+    await $auth.logout()
     return redirect('/users/login')
   }
+  store.commit('logoutUser')
 }

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -1,18 +1,22 @@
 export default async function ({ $auth, store, redirect, route }) {
+  const permissionPaths = [
+    `/users/login`,
+    '/users/login',
+    '/top',
+    '/offices',
+    '/users/privacy_policy',
+    '/users/terms',
+    '/users/contacts/new',
+    '/users/contacts/confirm',
+    '/users/contacts/success',
+    '/users/new',
+    '/users/send',
+    '/',
+  ]
   if (
-    route.path !== '/users/login' &&
-    route.path !== '/top' &&
-    route.path !== '/offices' &&
     route.name !== 'offices-id' &&
-    route.path !== '/users/privacy_policy' &&
-    route.path !== '/users/terms' &&
-    route.path !== '/users/contacts/new' &&
-    route.path !== '/users/contacts/confirm' &&
-    route.path !== '/users/contacts/success' &&
-    route.path !== '/users/new' &&
-    route.path !== '/users/send' &&
-    route.path !== '/' &&
-    store.state.customer !== 'true'
+    !permissionPaths.includes(route.path) &&
+    store.state.customer !== true
   ) {
     await $auth.logout()
     return redirect('/users/login')

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -6,7 +6,6 @@ export default function ({ store, redirect, route }) {
     route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'
   ) {
-    console.log('ミドルウェア')
     return redirect('/specialists/login')
   }
 }

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,0 +1,9 @@
+export default function ({ store, redirect, route }) {
+  if (
+    route.path !== '/specialists/login' &&
+    store.state.specialist !== 'true'
+  ) {
+    console.log('ミドルウェア')
+    return redirect('/specialists/login')
+  }
+}

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,6 +1,7 @@
 export default function ({ store, redirect, route }) {
   if (
     route.path !== '/specialists/login' &&
+    route.path !== '/specialists/users/new' &&
     store.state.specialist !== 'true'
   ) {
     console.log('ミドルウェア')

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,4 +1,4 @@
-export default async ({ $auth, store, redirect, route }) => {
+export default async function ({ $auth, store, redirect, route }) {
   if (
     route.path !== '/specialists/login' &&
     route.path !== '/specialists/users/new' &&
@@ -8,5 +8,4 @@ export default async ({ $auth, store, redirect, route }) => {
     await $auth.logout()
     return redirect('/specialists/login')
   }
-  store.commit('logoutUser')
 }

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,6 +1,7 @@
 export default function ({ store, redirect, route }) {
   if (
     route.path !== '/specialists/login' &&
+    route.path !== '/specialists/login/' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -3,7 +3,7 @@ export default async function ({ $auth, store, redirect, route }) {
     route.path !== '/specialists/login' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
-    store.state.specialist !== 'true'
+    store.state.specialist !== true
   ) {
     await $auth.logout()
     return redirect('/specialists/login')

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -2,6 +2,7 @@ export default function ({ store, redirect, route }) {
   if (
     route.path !== '/specialists/login' &&
     route.path !== '/specialists/users/new' &&
+    route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'
   ) {
     console.log('ミドルウェア')

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,7 +1,6 @@
 export default function ({ store, redirect, route }) {
   if (
     route.path !== '/specialists/login' &&
-    route.path !== '/specialists/login/' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,10 +1,11 @@
 export default function ({ store, redirect, route }) {
   if (
+    route.path !== '/specialists/login' &&
     route.path !== '/specialists/login/' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'
   ) {
-    return redirect('/specialists/login/')
+    return redirect('/specialists/login')
   }
 }

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,11 +1,10 @@
 export default function ({ store, redirect, route }) {
   if (
-    route.path !== '/specialists/login' &&
     route.path !== '/specialists/login/' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'
   ) {
-    return redirect('/specialists/login')
+    return redirect('/specialists/login/')
   }
 }

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,10 +1,12 @@
-export default function ({ store, redirect, route }) {
+export default async ({ $auth, store, redirect, route }) => {
   if (
     route.path !== '/specialists/login' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
     store.state.specialist !== 'true'
   ) {
+    await $auth.logout()
     return redirect('/specialists/login')
   }
+  store.commit('logoutUser')
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -42,6 +42,7 @@ export default {
   css: [],
 
   plugins: [
+    { src: '~/plugins/persistedstate.js' },
     '~/plugins/axios.js',
     '~/plugins/apiToRequestOfAddress.js',
     '~plugins/dateFilter.js',

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vue-server-renderer": "^2.6.14",
     "vue-template-compiler": "^2.6.14",
     "vuetify": "^2.6.1",
+    "vuex-persistedstate": "^4.1.0",
     "webpack": "^4.46.0"
   },
   "devDependencies": {

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -21,7 +21,6 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
         store.commit('loginSpecialist')
       } else if (loginInfo.user_type === 'customer') {
         store.commit('loginCustomer')
-        console.log('カスタマ')
       }
       return response
     } catch (error) {

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -19,6 +19,9 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
       redirect(loginInfo.redirectUrl)
       if (loginInfo.user_type === 'specialist') {
         store.commit('loginSpecialist')
+      } else if (loginInfo.user_type === 'customer') {
+        store.commit('loginCustomer')
+        console.log('カスタマ')
       }
       return response
     } catch (error) {

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -17,6 +17,9 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログインしました'])
       redirect(loginInfo.redirectUrl)
+      if (loginInfo.user_type === 'specialist') {
+        store.commit('loginSpecialist')
+      }
       return response
     } catch (error) {
       return error

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -11,6 +11,7 @@ export default function ({ $auth, redirect, store }, inject) {
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログアウトしました'])
       redirect(logoutInfo.redirectUrl)
+      store.commit('logoutSpecialist')
       return response
     } catch (error) {
       // TODO 失敗時にstoreにtype入れ込む

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -11,7 +11,7 @@ export default function ({ $auth, redirect, store }, inject) {
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログアウトしました'])
       redirect(logoutInfo.redirectUrl)
-      store.commit('logoutSpecialist')
+      store.commit('logoutUser')
       return response
     } catch (error) {
       // TODO 失敗時にstoreにtype入れ込む

--- a/plugins/persistedstate.js
+++ b/plugins/persistedstate.js
@@ -4,7 +4,7 @@ import cookie from 'cookie'
 
 export default ({ store, req }) => {
   createPersistedState({
-    paths: ['specialist', 'message'],
+    paths: ['specialist'],
     storage: {
       getItem: (key) => {
         // See https://nuxtjs.org/guide/plugins/#using-process-flags

--- a/plugins/persistedstate.js
+++ b/plugins/persistedstate.js
@@ -8,7 +8,7 @@ export default ({ store, req }) => {
     storage: {
       getItem: (key) => {
         // See https://nuxtjs.org/guide/plugins/#using-process-flags
-        if (process.server) {
+        if (process.server && req.headers.cookie) {
           const parsedCookies = cookie.parse(req.headers.cookie)
           return parsedCookies[key]
         } else {

--- a/plugins/persistedstate.js
+++ b/plugins/persistedstate.js
@@ -1,0 +1,23 @@
+import createPersistedState from 'vuex-persistedstate'
+import * as Cookies from 'js-cookie'
+import cookie from 'cookie'
+
+export default ({ store, req }) => {
+  createPersistedState({
+    storage: {
+      getItem: (key) => {
+        // See https://nuxtjs.org/guide/plugins/#using-process-flags
+        if (process.server) {
+          const parsedCookies = cookie.parse(req.headers.cookie)
+          return parsedCookies[key]
+        } else {
+          return Cookies.get(key)
+        }
+      },
+      // Please see https://github.com/js-cookie/js-cookie#json, on how to handle JSON.
+      setItem: (key, value) =>
+        Cookies.set(key, value, { expires: 365, secure: false }),
+      removeItem: (key) => Cookies.remove(key),
+    },
+  })(store)
+}

--- a/plugins/persistedstate.js
+++ b/plugins/persistedstate.js
@@ -4,6 +4,7 @@ import cookie from 'cookie'
 
 export default ({ store, req }) => {
   createPersistedState({
+    paths: ['specialist', 'message'],
     storage: {
       getItem: (key) => {
         // See https://nuxtjs.org/guide/plugins/#using-process-flags

--- a/plugins/persistedstate.js
+++ b/plugins/persistedstate.js
@@ -4,7 +4,7 @@ import cookie from 'cookie'
 
 export default ({ store, req }) => {
   createPersistedState({
-    paths: ['specialist'],
+    paths: ['specialist', 'customer'],
     storage: {
       getItem: (key) => {
         // See https://nuxtjs.org/guide/plugins/#using-process-flags

--- a/store/index.js
+++ b/store/index.js
@@ -1,19 +1,19 @@
 // import createPersistedState from 'vuex-persistedstate'
 
 export const state = () => ({
-  specialist: 'false',
-  customer: 'false',
+  specialist: false,
+  customer: false,
 })
 
 export const mutations = {
   loginSpecialist(state) {
-    state.specialist = 'true'
+    state.specialist = true
   },
   logoutUser(state) {
-    state.specialist = 'false'
-    state.customer = 'false'
+    state.specialist = false
+    state.customer = false
   },
   loginCustomer(state) {
-    state.customer = 'true'
+    state.customer = true
   },
 }

--- a/store/index.js
+++ b/store/index.js
@@ -1,7 +1,6 @@
 // import createPersistedState from 'vuex-persistedstate'
 
 export const state = () => ({
-  message: 'Hello World',
   specialist: '',
 })
 

--- a/store/index.js
+++ b/store/index.js
@@ -1,14 +1,19 @@
 // import createPersistedState from 'vuex-persistedstate'
 
 export const state = () => ({
-  specialist: '',
+  specialist: 'false',
+  customer: 'false',
 })
 
 export const mutations = {
   loginSpecialist(state) {
     state.specialist = 'true'
   },
-  logoutSpecialist(state) {
-    state.specialist = ''
+  logoutUser(state) {
+    state.specialist = 'false'
+    state.customer = 'false'
+  },
+  loginCustomer(state) {
+    state.customer = 'true'
   },
 }

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,15 @@
+// import createPersistedState from 'vuex-persistedstate'
+
+export const state = () => ({
+  message: 'Hello World',
+  specialist: '',
+})
+
+export const mutations = {
+  loginSpecialist(state) {
+    state.specialist = 'true'
+  },
+  logoutSpecialist(state) {
+    state.specialist = ''
+  },
+}

--- a/test/e2e/specialists/A_signup_to_login.spec.js
+++ b/test/e2e/specialists/A_signup_to_login.spec.js
@@ -35,7 +35,7 @@ describe('ケアマネージャーが新規登録してログインできる', (
     url = await page.mainFrame().url()
     ele = await page.$('h6')
     titleText = await page.evaluate((elm) => elm.textContent, ele)
-    await expect(url).toEqual('http://localhost:8000/specialists/login/')
+    await expect(url).toEqual('http://localhost:8000/specialists/login')
     await expect(titleText).toEqual('ログイン')
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10704,6 +10704,11 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -12159,6 +12164,14 @@ vuetify@^2.6, vuetify@^2.6.1:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.6.4.tgz#18052f77492d32856fea35c910755075ff32acc9"
   integrity sha512-2wEzU/Gz39gQCxK93xoiWPKCHQUnyUKWd81wB7Q7hfYJWu5QOWQXYlF0X/BgUZzf8IOyHWKiSNEAfEe9OE3b4w==
+
+vuex-persistedstate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"
+  integrity sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
## やったこと

- ケアマネ・カスタマー画面のログイン制限

## やらないこと

- なし

## できるようになること（ユーザ目線）

- カスタマー画面からログインし、ケアマネのURLを直打ちしてもページが表示されずリダイレクトする
- ケアマネ画面からログインし、カスタマーのURLを直打ちしてもページが表示されずリダイレクトする

## できなくなること（ユーザ目線）

- なし
# **必要なかったら消すこと**

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/develop
```

# **必要なかったら消すこと**

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/login_limit

yarn install
```


### 動作確認 Loom 手順

手順1.カスタマーでログインする
手順2.ケアマネログイン後の画面のURLを直打ちする
手順3.ケアマネログイン画面に遷移される
  [手順動画](https://www.loom.com/share/e6e4d63ad6874199a5c3d617f60f6b69)

（カスタマーも同じ）

## その他
なし

