### PR TITLE
左上アイコンをクリックをurl直うちから router.pushで遷移するように設定

### DIFF
--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -9,7 +9,6 @@
               <div class="red--text">
                 <p class="ma-0">
                   <img
-                    class=""
                     src="~/assets/images/header-icon.svg"
                     width="157.44"
                     height="28"
@@ -369,7 +368,7 @@ export default {
   },
   methods: {
     topPage() {
-      window.location.href = 'http://localhost:8000/top'
+      this.$router.push('/top')
     },
   },
 }

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -488,7 +488,7 @@ export default {
 
   methods: {
     topPage() {
-      window.location.href = 'http://localhost:8000/specialists/login'
+      this.$router.push('/specialists/login')
     },
   },
 }

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -488,7 +488,14 @@ export default {
 
   methods: {
     topPage() {
+      this.$auth.loggedIn ? this.goAppointmentsPage() : this.goLoginPage()
+    },
+    goLoginPage() {
       this.$router.push('/specialists/login')
+    },
+    goAppointmentsPage() {
+      // TODO ルーティングを specialists/office/appointmentsに変える
+      this.$router.push(`/specialists/office/${1}/appointments`)
     },
   },
 }


### PR DESCRIPTION
## やったこと

- 左上のアイコンクリックすると、今まではurl直うちだったので本番環境だと開発環境に戻ってしまっていたのをrouter.pushに変えたので環境に依存しない画面遷移が可能になる。

## やらないこと

- 下記のような形のものは、ルーティングを変えたほうが良い `specialist`と`office`は1:1だから
  - 現状
`api/specialist/office/office_id/**/**`
  - 変えた形(office_idなしver)
`api/specialist/office/**/**`

## できるようになること（ユーザ目線）

- 本番環境でも画面遷移できる 開発には飛ばなくなる

## できなくなること（ユーザ目線）

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/layout-icon-link
```

### 動作確認手順
トップ以外のページからアイコンクリックして、トップ画面へ遷移(カスタマー)

ログイン画面以外からアイコンクリックして、ログイン画面へ遷移(ケアマネ)
ログインしてたら、予約状況に遷移(ケアマネ)