### PR TITLE
事業所一覧画面からブックマーク登録・解除

### DIFF
--- a/components/office/officeAreaList.vue
+++ b/components/office/officeAreaList.vue
@@ -143,19 +143,19 @@ export default {
   layout: 'application',
   props: {
     area: {
-      type: String,
+      type: [String, Array],
       default() {
         return undefined
       },
     },
     prefecture: {
-      type: String,
+      type: [String, Array],
       default() {
         return undefined
       },
     },
     cities: {
-      type: String,
+      type: [String, Array],
       default() {
         return undefined
       },
@@ -202,31 +202,6 @@ export default {
       stampPrefecture: '',
     }
   },
-  async fetch() {
-    if (this.propsUndefined()) {
-      this.e1 = 1
-      return
-    }
-    const list = []
-    for (let i = 0; i < this.selectedList.length; i++) {
-      list.push(Number(this.selectedList[i]))
-    }
-    this.selectedCityNum = list
-    if (!(this.area === undefined && this.area === '')) {
-      this.FetchPrefectures(decodeURI(this.area))
-    }
-    try {
-      const prefecture = this.prefecture
-      const res = await this.$apiToAddressJson.$get(
-        `json?method=getCities&prefecture=${prefecture}`
-      )
-      this.fetchCities = res.response.location
-      this.e1 = 3
-    } catch (error) {
-      // console.log(error)
-      return error
-    }
-  },
   computed: {
     ...mapGetters('areaData', ['getCurrentArea', 'getCurrentPrefecture']),
   },
@@ -248,7 +223,35 @@ export default {
       }
     },
   },
+  mounted() {
+    setTimeout(this.getOffice, 1000)
+  },
   methods: {
+    async getOffice() {
+      if (this.propsUndefined()) {
+        this.e1 = 1
+        return
+      }
+      const list = []
+      for (let i = 0; i < this.selectedList.length; i++) {
+        list.push(Number(this.selectedList[i]))
+      }
+      this.selectedCityNum = list
+      if (!(this.area === undefined && this.area === '')) {
+        this.FetchPrefectures(decodeURI(this.area))
+      }
+      try {
+        const prefecture = this.prefecture
+        const res = await this.$apiToAddressJson.$get(
+          `json?method=getCities&prefecture=${prefecture}`
+        )
+        this.fetchCities = res.response.location
+        this.e1 = 3
+      } catch (error) {
+        // console.log(error)
+        return error
+      }
+    },
     searchOffice() {
       const array = []
       for (let i = 0; i < this.selectedCityNum.length; i++) {

--- a/components/office/officeBookmarkBtn.vue
+++ b/components/office/officeBookmarkBtn.vue
@@ -1,0 +1,93 @@
+<template>
+  <v-avatar
+    color="#F5F7F7"
+    class="ml-auto"
+    @mouseover="hoverActive"
+    @mouseleave="hoverRelease"
+    @click.stop="toggleBookmark"
+  >
+    <v-icon large :color="switchIconColor(icon.color)">{{ icon.state }}</v-icon>
+  </v-avatar>
+</template>
+
+<script>
+export default {
+  props: {
+    bookmark: {
+      type: [Object, String],
+      default() {
+        return null
+      },
+    },
+    officeId: {
+      type: Number,
+      default() {
+        return 0
+      },
+    },
+  },
+  data() {
+    return {
+      icon: {
+        state: 'mdi-star',
+        color: '#D9DEDE',
+      },
+    }
+  },
+  computed: {
+    getBookmark() {
+      return this.bookmark
+    },
+    getOfficeId() {
+      return this.officeId
+    },
+  },
+  methods: {
+    hoverActive() {
+      if (this.getBookmark === null) {
+        this.icon.color = '#F09C3C'
+      } else {
+        return true
+      }
+    },
+    hoverRelease() {
+      if (this.getBookmark === null) {
+        this.icon.color = '#D9DEDE'
+      } else {
+        return true
+      }
+    },
+    toggleBookmark() {
+      if (this.$auth.loggedIn) {
+        if (this.getBookmark === null) {
+          // お気に入りしてないなら、登録処理
+          this.$emit('grandChild-event-submit-bookmark', this.getOfficeId)
+        } else {
+          // お気に入り済みなら、解除処理
+          this.$emit(
+            'grandChild-event-destroy-bookmark',
+            this.getOfficeId,
+            this.getBookmark.id
+          )
+        }
+      } else {
+        alert('お気に入り機能はログインしたら利用できます。')
+      }
+    },
+    switchIconColor(item) {
+      if (this.getBookmark === null) {
+        return item
+      } else {
+        const array = Object.entries(this.getBookmark).map(([key, value]) => ({
+          key,
+          value,
+        }))
+        if (array.length === 0) {
+          return item
+        }
+        return '#F09C3C'
+      }
+    },
+  },
+}
+</script>

--- a/components/office/officeCard.vue
+++ b/components/office/officeCard.vue
@@ -123,10 +123,6 @@ export default {
   },
   data() {
     return {
-      icon: {
-        state: 'fa-regular fa-star',
-        color: '#D9DEDE',
-      },
       week: ['日', '月', '火', '水', '木', '金', '土'],
       binaryNumber: [64, 32, 16, 8, 4, 2, 1],
       // binaryNumber: [1, 2, 4, 8, 16, 32, 64],
@@ -174,22 +170,6 @@ export default {
   methods: {
     moveShow() {
       this.$router.push({ path: `/offices/${this.office.id}` })
-    },
-    hoverActive() {
-      this.icon.color = '#F09C3C'
-    },
-    hoverRelease() {
-      // お気に入り済みなら、なにもしない
-      this.icon.color = '#D9DEDE'
-    },
-    toggleBookmark() {
-      // お気に入り済みなら、解除処理
-      // お気に入りしてないなら、登録処理
-      if (this.$auth.loggedIn) {
-        alert('お気に入り機能はまだ実装されていません。')
-      } else {
-        alert('お気に入り機能はログインしたら利用できます。')
-      }
     },
     conversionBinaryToHolidayArray(holiday) {
       const array = []

--- a/components/office/officeCard.vue
+++ b/components/office/officeCard.vue
@@ -18,15 +18,12 @@
       </v-chip>
       <v-card-title class="py-2 px-0 d-flex flex-nowrap">
         <h5 class="set-max-layout">{{ office.name }}</h5>
-        <v-avatar
-          color="#F5F7F7"
-          class="ml-auto"
-          @mouseover="hoverActive()"
-          @mouseleave="hoverRelease()"
-          @click.stop="toggleBookmark()"
-        >
-          <v-icon :color="icon.color">{{ icon.state }}</v-icon>
-        </v-avatar>
+        <office-bookmark-btn
+          :bookmark="office.bookmark"
+          :office-id="office.id"
+          @grandChild-event-submit-bookmark="submitBookmark"
+          @grandChild-event-destroy-bookmark="destroyBookmark"
+        />
       </v-card-title>
       <div class="d-flex">
         <v-img
@@ -171,7 +168,7 @@ export default {
       ]
     },
     holidayArray() {
-      return this.conversionBinaryToholidayArray(this.office.flags)
+      return this.conversionBinaryToHolidayArray(this.office.flags)
     },
   },
   methods: {
@@ -194,17 +191,17 @@ export default {
         alert('お気に入り機能はログインしたら利用できます。')
       }
     },
-    conversionBinaryToholidayArray(holiday) {
-      const arry = []
+    conversionBinaryToHolidayArray(holiday) {
+      const array = []
       this.binaryNumber.forEach((n) => {
         if (holiday >= n) {
           holiday = holiday - n
-          arry.push(1)
+          array.push(1)
         } else {
-          arry.push(0)
+          array.push(0)
         }
       })
-      return arry.reverse()
+      return array.reverse()
     },
     toggleSymbol(n) {
       return n === 1 ? 'mdi-close' : 'mdi-circle-outline'
@@ -228,6 +225,29 @@ export default {
           default:
             return '#AEB5B2'
         }
+      }
+    },
+    async submitBookmark(officeId) {
+      try {
+        await this.$axios.$post(`offices/${officeId}/bookmarks`, {
+          office_id: officeId,
+        })
+        this.$emit('getOffice')
+      } catch (error) {
+        return error
+      }
+    },
+    async destroyBookmark(officeId, bookmarkId) {
+      try {
+        await this.$axios.$delete(
+          `offices/${officeId}/bookmarks/${bookmarkId}`,
+          {
+            office_id: officeId,
+          }
+        )
+        this.$emit('getOffice')
+      } catch (error) {
+        return error
       }
     },
   },

--- a/components/office/officeDataCardPc.vue
+++ b/components/office/officeDataCardPc.vue
@@ -107,10 +107,6 @@ export default {
   },
   data() {
     return {
-      icon: {
-        state: 'mdi-star',
-        color: '#D9DEDE',
-      },
       week: ['日', '月', '火', '水', '木', '金', '土'],
       binaryNumber: [64, 32, 16, 8, 4, 2, 1],
     }

--- a/components/office/officeDataCardPc.vue
+++ b/components/office/officeDataCardPc.vue
@@ -2,17 +2,12 @@
   <v-card class="sm-under-no sticky" tile>
     <v-card-title class="py-2 px-3 d-flex flex-nowrap">
       <h3 class="set-max-layout">{{ office.name }}</h3>
-      <v-avatar
-        color="#F5F7F7"
-        class="ml-auto"
-        @mouseover="hoverActive"
-        @mouseleave="hoverRelease"
-        @click.stop="toggleBookmark"
-      >
-        <v-icon large :color="switchIconColor(icon.color)">{{
-          icon.state
-        }}</v-icon>
-      </v-avatar>
+      <office-bookmark-btn
+        :bookmark="bookmark"
+        :office-id="officeId"
+        @grandChild-event-submit-bookmark="childEventSubmitBookmark"
+        @grandChild-event-destroy-bookmark="childEventDestroyBookmark"
+      />
     </v-card-title>
     <v-row class="mx-auto mt-auto max-width">
       <v-col cols="12">
@@ -104,7 +99,7 @@ export default {
       },
     },
     bookmark: {
-      type: [Array, Object],
+      type: [Object, String],
       default() {
         return null
       },
@@ -126,33 +121,6 @@ export default {
     },
   },
   methods: {
-    hoverActive() {
-      if (this.bookmark === null) {
-        this.icon.color = '#F09C3C'
-      } else {
-        return true
-      }
-    },
-    hoverRelease() {
-      if (this.bookmark === null) {
-        this.icon.color = '#D9DEDE'
-      } else {
-        return true
-      }
-    },
-    toggleBookmark() {
-      if (this.$auth.loggedIn) {
-        if (this.bookmark === null) {
-          // お気に入りしてないなら、登録処理
-          this.$emit('submitBookmark', this.officeId)
-        } else {
-          // お気に入り済みなら、解除処理
-          this.$emit('destroyBookmark', this.officeId, this.bookmark.id)
-        }
-      } else {
-        alert('お気に入り機能はログインしたら利用できます。')
-      }
-    },
     goAppointmentsPage() {
       if (!this.$auth.loggedIn) {
         return alert('ログインをする必要があります')
@@ -175,20 +143,6 @@ export default {
     toggleSymbol(n) {
       return n === 1 ? 'mdi-close' : 'mdi-circle-outline'
     },
-    switchIconColor(item) {
-      if (this.bookmark === null) {
-        return item
-      } else {
-        const array = Object.entries(this.bookmark).map(([key, value]) => ({
-          key,
-          value,
-        }))
-        if (array.length === 0) {
-          return item
-        }
-        return '#F09C3C'
-      }
-    },
     switchColor(item) {
       if (typeof item === 'string') {
         // 曜日の色を切替
@@ -209,6 +163,12 @@ export default {
             return '#AEB5B2'
         }
       }
+    },
+    childEventSubmitBookmark(officeId) {
+      this.$emit('submit-bookmark', officeId)
+    },
+    childEventDestroyBookmark(officeId, bookmarkId) {
+      this.$emit('destroy-bookmark', officeId, bookmarkId)
     },
   },
 }

--- a/components/office/officeDataCardSp.vue
+++ b/components/office/officeDataCardSp.vue
@@ -99,10 +99,6 @@ export default {
   },
   data() {
     return {
-      icon: {
-        state: 'mdi-star',
-        color: '#D9DEDE',
-      },
       week: ['日', '月', '火', '水', '木', '金', '土'],
       binaryNumber: [64, 32, 16, 8, 4, 2, 1],
     }

--- a/components/office/officeDataCardSp.vue
+++ b/components/office/officeDataCardSp.vue
@@ -2,17 +2,12 @@
   <v-card class="md-over-no" tile>
     <v-card-title class="py-2 px-3 d-flex flex-nowrap">
       <h3 class="set-max-layout">{{ office.name }}</h3>
-      <v-avatar
-        color="#F5F7F7"
-        class="ml-auto"
-        @mouseover="hoverActive"
-        @mouseleave="hoverRelease"
-        @click.stop="toggleBookmark"
-      >
-        <v-icon large :color="switchIconColor(icon.color)">{{
-          icon.state
-        }}</v-icon>
-      </v-avatar>
+      <office-bookmark-btn
+        :bookmark="bookmark"
+        :office-id="officeId"
+        @grandChild-event-submit-bookmark="childEventSubmitBookmark"
+        @grandChild-event-destroy-bookmark="childEventDestroyBookmark"
+      />
     </v-card-title>
     <v-col cols="12">
       <div class="office-tel">
@@ -118,47 +113,6 @@ export default {
     },
   },
   methods: {
-    hoverActive() {
-      if (this.bookmark === null) {
-        this.icon.color = '#F09C3C'
-      } else {
-        return true
-      }
-    },
-    hoverRelease() {
-      if (this.bookmark === null) {
-        this.icon.color = '#D9DEDE'
-      } else {
-        return true
-      }
-    },
-    toggleBookmark() {
-      if (this.$auth.loggedIn) {
-        if (this.bookmark === null) {
-          // お気に入りしてないなら、登録処理
-          this.$emit('submitBookmark', this.officeId)
-        } else {
-          // お気に入り済みなら、解除処理
-          this.$emit('destroyBookmark', this.officeId, this.bookmark.id)
-        }
-      } else {
-        alert('お気に入り機能はログインしたら利用できます。')
-      }
-    },
-    switchIconColor(item) {
-      if (this.bookmark === null) {
-        return item
-      } else {
-        const array = Object.entries(this.bookmark).map(([key, value]) => ({
-          key,
-          value,
-        }))
-        if (array.length === 0) {
-          return item
-        }
-        return '#F09C3C'
-      }
-    },
     goAppointmentsPage() {
       if (!this.$auth.loggedIn) {
         return alert('ログインをする必要があります')
@@ -201,6 +155,12 @@ export default {
             return '#AEB5B2'
         }
       }
+    },
+    childEventSubmitBookmark(officeId) {
+      this.$emit('submit-bookmark', officeId)
+    },
+    childEventDestroyBookmark(officeId, bookmarkId) {
+      this.$emit('destroy-bookmark', officeId, bookmarkId)
     },
   },
 }

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -8,8 +8,8 @@
           :office="office"
           :staffs="staffs"
           :bookmark="bookmark"
-          @submitBookmark="submitBookmark"
-          @destroyBookmark="destroyBookmark"
+          @submit-bookmark="submitBookmark"
+          @destroy-bookmark="destroyBookmark"
         />
         <office-detail-card :office="office" />
         <office-staff-card :office="office" :staffs="staffs" />
@@ -21,8 +21,8 @@
           :office="office"
           :staffs="staffs"
           :bookmark="bookmark"
-          @submitBookmark="submitBookmark"
-          @destroyBookmark="destroyBookmark"
+          @submit-bookmark="submitBookmark"
+          @destroy-bookmark="destroyBookmark"
         />
       </v-col>
     </v-row>
@@ -47,7 +47,7 @@ export default {
   data() {
     return {
       office_id: this.$route.params.id,
-      bookmark: [],
+      bookmark: {},
     }
   },
   mounted() {
@@ -60,7 +60,7 @@ export default {
           `offices/${this.office_id}/bookmarks`
         )
         this.getAPI = response
-        this.bookmark = this.getAPI.bookmark.find((item) => item)
+        this.bookmark = this.getAPI.bookmark
       } catch (error) {
         return error
       }

--- a/test/e2e/users/Z_access_footer_link.spec.js
+++ b/test/e2e/users/Z_access_footer_link.spec.js
@@ -47,7 +47,10 @@ describe('ユーザーがフッターのリンクにすべてアクセスでき�
   })
   describe('ユーザーがログアウトをする', () => {
     it('ログアウトボタンを押し、ログアウトする', async () => {
-      await page.click('#header-logout')
+      await Promise.all([
+        page.waitForNavigation({ timeout: 6000, waitUntil: 'load' }),
+        page.click('#header-logout'),
+      ])
 
       url = await page.mainFrame().url()
       text = await page.evaluate(() => document.body.textContent)


### PR DESCRIPTION
## やったこと

- 事業所一覧画面からブックマーク登録・解除機能

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/bookmark-create-destroy
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/submit-destroy-bookmark
```

### 動作確認 Loom 手順

- 既存のコードを大きく変更しているので、検索機能や、検索した事業所が取得できるかの確認をお願いします
- 検索した事業所をブックマーク登録・解除する
- ★アイコンの色が変わっていればOK
- ページをリロードする
- ブックマークデータが保持されていればOK
## 工夫したところ
- ブックマークボタンをコンポーネント化し、ブックマークボタンのあるページはコンポーネントを呼び出すだけになり、同じことを毎回書かずに済み、コードがスッキリした
## 参考になったサイト
- 関数の実行タイミングを指定秒数遅らせる
  - getOfficeメソッド内でpropsの値を取得しているが、propsの読み込みが終わる前に処理が走ってしまいエラーが出てしまうため、指定秒数待ってからメソッドを呼び出すようにしています。この書き方はあまりよくないですが、現状きれいな書き方が見つかっておらず、このような対応を取っています。
 
`components/office/officeAreaList.vue`
```javascript
mounted() {
    setTimeout(this.getOffice, 1000)
  },
```
[Vue.jsでsetTimeoutする時の注意点](https://h2r4t.hatenablog.com/entry/2018/05/20/215509)
