### PR TITLE
スタッフ紹介ページ並び替え

### DIFF
--- a/assets/images/account_icon.svg
+++ b/assets/images/account_icon.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 60 60"
+   version="1.1"
+   id="svg22"
+   sodipodi:docname="account_icon.svg"
+   width="60"
+   height="60"
+   inkscape:version="1.0.1 (c497b03c, 2020-09-10)"
+   inkscape:export-filename="/Users/takishitakouki/Downloads/icons_svg/account1.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <metadata
+     id="metadata30">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#3ede47"
+     borderopacity="0.29411765"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1858"
+     inkscape:window-height="996"
+     id="namedview24"
+     showgrid="false"
+     inkscape:showpageshadow="true"
+     borderlayer="false"
+     inkscape:zoom="3.4363365"
+     inkscape:cx="-7.3048023"
+     inkscape:cy="29.095586"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg22"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="false" />
+  <rect
+     style="fill:#d9dede;stroke-width:0.991248;fill-opacity:1"
+     id="rect16"
+     width="60"
+     height="60"
+     x="0"
+     y="0" />
+  <path
+     d="M 29.999999,15 A 7.4999997,7.5 0 0 1 37.500002,22.499999 7.4999997,7.5 0 0 1 29.999999,30 7.4999997,7.5 0 0 1 22.500001,22.499999 7.4999997,7.5 0 0 1 29.999999,15 m 0,18.749998 C 38.287499,33.749998 45,37.106238 45,41.25 V 45 H 15 v -3.75 c 0,-4.143762 6.712501,-7.500002 14.999999,-7.500002 z"
+     id="path20"
+     style="fill:#ffffff;stroke-width:1.87498" />
+</svg>

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card id="staff-introduction" outlined>
-    <v-row no-gutters justify="end" class="mb-4">
+    <v-row no-gutters justify="end">
       <v-col cols="3">
         <v-avatar size="80">
           <img :src="ReadStaff.image" />
@@ -61,6 +61,16 @@ export default {
     },
     grayColor() {
       return '#6D7570'
+    },
+    /*
+        return "mt-n6"
+    */
+    setMargin() {
+      if (this.$vuetify.breakpoint.smAndUp) {
+        return 'mt-n6'
+      } else {
+        return ''
+      }
     },
   },
   methods: {

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -8,7 +8,7 @@
       </v-col>
       <v-col cols="9">
         <v-row no-gutters>
-          <v-col cols="12" sm="3">
+          <v-col cols="12" sm="4">
             <div>
               <v-card-title class="pa-0 font-weight-black text-subtitle-1">
                 {{ staff.name }}
@@ -18,7 +18,7 @@
               </div>
             </div>
           </v-col>
-          <v-col cols="12" sm="9">
+          <v-col cols="12" sm="8">
             <v-card id="staff-introduction" class="set-line-height" outlined>
               <font size="2" :color="grayColor"
                 >{{ ReadStaff.introduction }}
@@ -62,9 +62,6 @@ export default {
     grayColor() {
       return '#6D7570'
     },
-    /*
-        return "mt-n6"
-    */
     setMargin() {
       if (this.$vuetify.breakpoint.smAndUp) {
         return 'mt-n6'

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -9,7 +9,7 @@
       <v-col cols="9">
         <v-row no-gutters>
           <v-col cols="12" sm="3">
-            <div class="">
+            <div>
               <v-card-title class="pa-0 font-weight-black text-subtitle-1">
                 {{ staff.name }}
               </v-card-title>
@@ -19,12 +19,7 @@
             </div>
           </v-col>
           <v-col cols="12" sm="9">
-            <v-card
-              id="staff-introduction"
-              class="set-line-height"
-              outlined
-              max-width="206"
-            >
+            <v-card id="staff-introduction" class="set-line-height" outlined>
               <font size="2" :color="grayColor"
                 >{{ ReadStaff.introduction }}
               </font>

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -19,7 +19,11 @@
             </div>
           </v-col>
           <v-col cols="12" sm="8">
-            <v-card id="staff-introduction" class="set-line-height" outlined>
+            <v-card
+              id="staff-introduction"
+              class="set-line-height text-truncate"
+              outlined
+            >
               <font size="2" :color="grayColor"
                 >{{ ReadStaff.introduction }}
               </font>

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -2,8 +2,8 @@
   <v-card id="staff-introduction" outlined>
     <v-row no-gutters justify="end">
       <v-col cols="3">
-        <v-avatar size="80">
-          <img :src="ReadStaff.image" />
+        <v-avatar size="70">
+          <img :src="imageUrl" />
         </v-avatar>
       </v-col>
       <v-col cols="9">
@@ -58,6 +58,9 @@ export default {
     },
     ReadThanks() {
       return this.ReadStaff.thanks
+    },
+    imageUrl() {
+      return this.ReadStaff.image || require('~/assets/images/account_icon.svg')
     },
     grayColor() {
       return '#6D7570'

--- a/components/staff/introductionCard.vue
+++ b/components/staff/introductionCard.vue
@@ -61,6 +61,7 @@ export default {
       return this.staff
     },
     ReadThanks() {
+      if (typeof this.ReadStaff.thanks === 'number') return [0]
       return this.ReadStaff.thanks
     },
     imageUrl() {

--- a/components/staff/thankCard.vue
+++ b/components/staff/thankCard.vue
@@ -1,8 +1,5 @@
 <template>
   <div :class="setSpaceY">
-    <p v-if="isIndexNumOne" class="ma-0 my-1 text-right" @click="toggleList">
-      {{ toggleMessage }}
-    </p>
     <v-card
       v-if="isIndexNumZero"
       min-height="61"
@@ -26,6 +23,9 @@
         </v-col>
       </v-row>
     </v-card>
+    <p v-if="isIndexNumOne" class="ma-0 text-right my-1" @click="toggleList">
+      {{ toggleMessage }}
+    </p>
   </div>
 </template>
 <script>
@@ -65,11 +65,21 @@ export default {
       return 'rgba(169, 240, 209, 16%)'
     },
     setSpaceY() {
-      if (this.indexNum > 0) {
-        return 'my-1'
-      } else {
-        return ''
+      let margin
+      if (this.ReadIndexNum === 0) {
+        if (this.$vuetify.breakpoint.xs) {
+          margin = 'mt-4'
+        } else {
+          margin = 'mt-n6'
+        }
+      } else if (
+        this.ReadOpen &&
+        this.ReadIndexNum > 0 &&
+        this.ReadCount - 1 !== this.ReadIndexNum
+      ) {
+        margin = 'mb-2'
       }
+      return margin
     },
     toggleMessage() {
       let msg
@@ -81,7 +91,7 @@ export default {
       return msg
     },
     isIndexNumOne() {
-      if (this.ReadIndexNum === 1) {
+      if (this.ReadIndexNum === 0) {
         return true
       } else {
         return false

--- a/components/staff/thankCard.vue
+++ b/components/staff/thankCard.vue
@@ -18,7 +18,7 @@
             </p>
           </v-card-title>
           <v-card-text class="pa-0 text-caption min-line-height">
-            <p class="mb-0">{{ ReadThank.comments }}</p>
+            <p class="mb-0">{{ ReadThankComments }}</p>
           </v-card-text>
         </v-col>
       </v-row>
@@ -37,7 +37,7 @@
 export default {
   props: {
     thank: {
-      type: Object,
+      type: [Object, Number],
       default: null,
     },
     indexNum: {
@@ -65,6 +65,15 @@ export default {
     },
     ReadCount() {
       return this.count
+    },
+    ReadThankComments() {
+      let msg
+      if (typeof this.ReadThank === 'number') {
+        msg = 'お礼はまだ投稿されていません'
+      } else {
+        msg = this.ReadThank.comments
+      }
+      return msg
     },
     lightGreen() {
       return 'rgba(169, 240, 209, 16%)'

--- a/components/staff/thankCard.vue
+++ b/components/staff/thankCard.vue
@@ -91,7 +91,7 @@ export default {
       return msg
     },
     isIndexNumOne() {
-      if (this.ReadIndexNum === 0) {
+      if (this.ReadIndexNum === 0 && this.ReadCount > 1) {
         return true
       } else {
         return false

--- a/components/staff/thankCard.vue
+++ b/components/staff/thankCard.vue
@@ -23,8 +23,13 @@
         </v-col>
       </v-row>
     </v-card>
-    <p v-if="isIndexNumOne" class="ma-0 text-right my-1" @click="toggleList">
-      {{ toggleMessage }}
+    <p
+      v-if="isIndexNumOne"
+      class="ma-0 text-right my-1 text-caption font-weight-black"
+      @click="toggleList"
+    >
+      <font :color="linkColor">{{ toggleMessage }}</font>
+      <v-icon :color="linkColor" class="mt-n1">{{ toggleIcon }}</v-icon>
     </p>
   </div>
 </template>
@@ -64,6 +69,9 @@ export default {
     lightGreen() {
       return 'rgba(169, 240, 209, 16%)'
     },
+    linkColor() {
+      return '#F06364'
+    },
     setSpaceY() {
       let margin
       if (this.ReadIndexNum === 0) {
@@ -89,6 +97,15 @@ export default {
         msg = `ほかの${this.ReadCount - 1}件のお礼を見る`
       }
       return msg
+    },
+    toggleIcon() {
+      let icon
+      if (this.isOpen) {
+        icon = 'mdi-chevron-up'
+      } else {
+        icon = 'mdi-chevron-down'
+      }
+      return icon
     },
     isIndexNumOne() {
       if (this.ReadIndexNum === 0 && this.ReadCount > 1) {


### PR DESCRIPTION
## やったこと

1. 事業所詳細画面のスタッフ紹介カードにて、スタッフの並び順をお礼の数が多い順に並び替え
2. スタイルの整えた(PC、スマホ対応)

## やらないこと

- なし

### API 側

- fetch and checkout ↓こちらのプルリクも確認
https://github.com/koki-takishita/home-care-navi-api/pull/93
```ruby
git fetch && git checkout origin/feature/staffs-thanks-sort
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/staff-introduction-layout
```

### 動作確認 Loom 手順
- オフィス詳細ページへアクセス
- スタッフの並び順がお礼の数が多い順なことを確認する
※ お礼がない場合は作成する必要あり
  [LOOM手順動画](https://www.loom.com/share/401ef65a39e34271b15da3c7c99e69e9)


### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/6907b213-a23b-41ef-aba0-bc451eecbf23/specs/)  

### その他
- スタッフの画像が登録されていない場合は↓画像が表示されます。
[![Image from Gyazo](https://i.gyazo.com/cad7876c91b877f9e56cefc134d4defa.png)](https://gyazo.com/cad7876c91b877f9e56cefc134d4defa)
- お礼がそもそも１件しかなくて、並び替えが確認できない場合は作成する必要があります。 