### PR TITLE
mountedで一瞬だけ見えてはいけないものが見える問題　解決

### DIFF
--- a/components/office/officeAreaList.vue
+++ b/components/office/officeAreaList.vue
@@ -143,19 +143,19 @@ export default {
   layout: 'application',
   props: {
     area: {
-      type: [String, Array],
+      type: String,
       default() {
         return undefined
       },
     },
     prefecture: {
-      type: [String, Array],
+      type: String,
       default() {
         return undefined
       },
     },
     cities: {
-      type: [String, Array],
+      type: String,
       default() {
         return undefined
       },
@@ -202,6 +202,31 @@ export default {
       stampPrefecture: '',
     }
   },
+  async fetch() {
+    if (this.propsUndefined()) {
+      this.e1 = 1
+      return
+    }
+    const list = []
+    for (let i = 0; i < this.selectedList.length; i++) {
+      list.push(Number(this.selectedList[i]))
+    }
+    this.selectedCityNum = list
+    if (!(this.area === undefined && this.area === '')) {
+      this.FetchPrefectures(decodeURI(this.area))
+    }
+    try {
+      const prefecture = this.prefecture
+      const res = await this.$apiToAddressJson.$get(
+        `json?method=getCities&prefecture=${prefecture}`
+      )
+      this.fetchCities = res.response.location
+      this.e1 = 3
+    } catch (error) {
+      // console.log(error)
+      return error
+    }
+  },
   computed: {
     ...mapGetters('areaData', ['getCurrentArea', 'getCurrentPrefecture']),
   },
@@ -223,35 +248,7 @@ export default {
       }
     },
   },
-  mounted() {
-    setTimeout(this.getOffice, 1000)
-  },
   methods: {
-    async getOffice() {
-      if (this.propsUndefined()) {
-        this.e1 = 1
-        return
-      }
-      const list = []
-      for (let i = 0; i < this.selectedList.length; i++) {
-        list.push(Number(this.selectedList[i]))
-      }
-      this.selectedCityNum = list
-      if (!(this.area === undefined && this.area === '')) {
-        this.FetchPrefectures(decodeURI(this.area))
-      }
-      try {
-        const prefecture = this.prefecture
-        const res = await this.$apiToAddressJson.$get(
-          `json?method=getCities&prefecture=${prefecture}`
-        )
-        this.fetchCities = res.response.location
-        this.e1 = 3
-      } catch (error) {
-        // console.log(error)
-        return error
-      }
-    },
     searchOffice() {
       const array = []
       for (let i = 0; i < this.selectedCityNum.length; i++) {

--- a/components/office/officeCard.vue
+++ b/components/office/officeCard.vue
@@ -212,7 +212,7 @@ export default {
         await this.$axios.$post(`offices/${officeId}/bookmarks`, {
           office_id: officeId,
         })
-        this.$emit('getOffice')
+        this.$nuxt.refresh()
       } catch (error) {
         return error
       }
@@ -225,7 +225,7 @@ export default {
             office_id: officeId,
           }
         )
-        this.$emit('getOffice')
+        this.$nuxt.refresh()
       } catch (error) {
         return error
       }

--- a/pages/appointments/index.vue
+++ b/pages/appointments/index.vue
@@ -18,8 +18,8 @@
             <v-row>
               <v-avatar tile width="120" height="90" class="ml-6 mt-4 mb-8">
                 <v-img
-                  v-if="office.image_url !== null"
-                  :src="office.image_url[0]"
+                  v-if="office.image.length !== 0"
+                  :src="office.image"
                 ></v-img>
                 <v-img
                   v-else
@@ -34,7 +34,7 @@
                 <v-row class="pt-1">
                   <v-icon small>mdi-account</v-icon>
                   <div class="my-auto pl-1">
-                    スタッフ数 {{ office.staffs.length }}人
+                    スタッフ数 {{ office.staffCount }}人
                   </div>
                 </v-row>
                 <v-row class="pt-1">
@@ -46,37 +46,21 @@
             <v-divider class="mx-3"></v-divider>
             <v-col class="mt-2 font-color-gray text-caption"
               >予約した日時：{{
-                office.appointments[office.appointments.length - 1].created_at
-                  | created_at
+                office.appointment.created_at | created_at
               }}</v-col
             >
             <v-col class="pb-0 font-color-gray font-weight-black text-caption"
               >面談希望日時</v-col
             >
             <v-col class="py-0"
-              >{{
-                office.appointments[office.appointments.length - 1].meet_date
-                  | meet_date
-              }}
-              {{
-                office.appointments[office.appointments.length - 1].meet_time
-              }}</v-col
+              >{{ office.appointment.meet_date | meet_date }}
+              {{ office.appointment.meet_time }}</v-col
             >
             <v-col class="text-center pt-4 pb-6 font-color-gray">
-              <div
-                v-if="
-                  office.appointments[office.appointments.length - 1]
-                    .called_status === 'need_call'
-                "
-              >
+              <div v-if="office.appointment.called_status === 'need_call'">
                 事業所からの連絡をお待ち下さい
               </div>
-              <div
-                v-else-if="
-                  office.appointments[office.appointments.length - 1]
-                    .called_status === 'called'
-                "
-              >
+              <div v-else-if="office.appointment.called_status === 'called'">
                 連絡済み
               </div>
               <div v-else>キャンセル済み</div>
@@ -84,7 +68,7 @@
           </v-card>
         </v-col>
       </v-col>
-      <v-col v-show="isShow">予約履歴はありません</v-col>
+      <v-col v-if="getAPI.length === 0">予約履歴はありません</v-col>
     </v-row>
   </v-col>
 </template>
@@ -93,29 +77,17 @@
 export default {
   layout: 'application',
   middleware: 'authentication',
-  data() {
-    return {
-      getAPI: [],
-      isShow: false,
+  async asyncData({ $axios }) {
+    try {
+      const res = await $axios.$get(`appointments`)
+      return {
+        getAPI: res,
+      }
+    } catch (error) {
+      return error
     }
   },
-  mounted() {
-    this.getAppointments()
-  },
   methods: {
-    async getAppointments() {
-      try {
-        const response = await this.$axios.$get(`appointments`)
-        this.getAPI = response
-        if (this.getAPI.length === 0) {
-          this.isShow = true
-        } else {
-          this.isShow = false
-        }
-      } catch (error) {
-        return error
-      }
-    },
     moveShow(id) {
       this.$router.push({ path: `/offices/${id}` })
     },

--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -29,7 +29,7 @@
           </div>
           <v-row v-if="offices.length">
             <v-col v-for="(office, i) in offices" :key="i" cols="12" md="6">
-              <officeCard :office="office" @getOffice="getOffice" />
+              <officeCard :office="office" />
             </v-col>
           </v-row>
           <p v-else class="ma-0">条件にマッチする事業所は存在しません</p>
@@ -50,6 +50,78 @@
 import { mapActions } from 'vuex'
 export default {
   layout: 'application',
+  async asyncData({ $axios, query, redirect }) {
+    // console.log(query)
+    // ここにkeywordの内容も追記すればリロードも対応できる
+    const area = query.area || ''
+    const prefecture = query.prefecture || ''
+    const cities = query.cities || ''
+    const selectedList = query.selectedList || 0
+    const page = Number(query.page) || 1
+    const keywords = query.keywords || ''
+    const postCodes = query.postCodes || ''
+    let searchWind
+    let offsetPage
+    let offices
+    if (page > 1) {
+      offsetPage = page - 1
+    } else {
+      offsetPage = 0
+    }
+    try {
+      if (postCodes === '' && keywords === '') {
+        offices = await $axios.$get(
+          `offices?prefecture=${prefecture}&cities=${cities}&page=${offsetPage}`
+        )
+        searchWind = false
+      }
+      if (!!postCodes.length > 0 || !!keywords.length > 0) {
+        offices = await $axios.$get(
+          `offices?keywords=${encodeURI(
+            keywords
+          )}&postCodes=${postCodes}&page=${offsetPage}`
+        )
+        searchWind = true
+      }
+      if (offices.length === 0) {
+        alert('選択したエリアにオフィスは存在しません')
+        redirect('/top')
+      }
+      let searchIcon = { keyword: '' }
+      if (keywords.length > 0 && postCodes.length > 0) {
+        searchIcon.keyword = `${keywords},${postCodes}`
+      } else if (keywords.length > 0) {
+        searchIcon.keyword = `${keywords}`
+      } else if (postCodes.length > 0) {
+        searchIcon.keyword = `${postCodes}`
+      } else {
+        searchIcon = { keyword: '' }
+      }
+      let count = offices[0].count
+      count = count / 10 || 0
+      count = Math.ceil(count)
+      if (count === 0) {
+        count = 1
+      }
+      return {
+        offices,
+        area,
+        prefecture,
+        cities,
+        keywords,
+        postCodes,
+        selectedList,
+        count,
+        page,
+        searchWind,
+        searchIcon,
+      }
+    } catch (error) {
+      // リロードして消えるようだったら有効化 console.log(error)
+      // console.log(error)
+      return error
+    }
+  },
   data() {
     return {
       offices: [],
@@ -119,86 +191,8 @@ export default {
       }
     },
   },
-  mounted() {
-    this.getOffice()
-  },
   methods: {
     ...mapActions('areaData', ['resetStore']),
-    async getOffice() {
-      // console.log(query)
-      // ここにkeywordの内容も追記すればリロードも対応できる
-      const query = this.$route.query
-      const area = query.area || ''
-      const prefecture = query.prefecture || ''
-      const cities = query.cities || ''
-      const selectedList = query.selectedList || 0
-      const page = Number(query.page) || 1
-      const keywords = query.keywords || ''
-      const postCodes = query.postCodes || ''
-      let searchWind
-      let offsetPage
-      let offices
-      if (page > 1) {
-        offsetPage = page - 1
-      } else {
-        offsetPage = 0
-      }
-      try {
-        if (postCodes === '' && keywords === '') {
-          offices = await this.$axios.$get(
-            `offices?prefecture=${prefecture}&cities=${cities}&page=${offsetPage}`
-          )
-          searchWind = false
-        }
-        // OK
-        if (!!postCodes.length > 0 || !!keywords.length > 0) {
-          offices = await this.$axios.$get(
-            `offices?keywords=${encodeURI(
-              keywords
-            )}&postCodes=${postCodes}&page=${offsetPage}`
-          )
-          searchWind = true
-        }
-        // OK
-        if (offices.length === 0) {
-          alert('選択したエリアにオフィスは存在しません')
-          redirect('/top')
-        }
-        // OK
-        let searchIcon = { keyword: '' }
-        if (keywords.length > 0 && postCodes.length > 0) {
-          searchIcon.keyword = `${keywords},${postCodes}`
-        } else if (keywords.length > 0) {
-          searchIcon.keyword = `${keywords}`
-        } else if (postCodes.length > 0) {
-          searchIcon.keyword = `${postCodes}`
-        } else {
-          searchIcon = { keyword: '' }
-        }
-
-        let count = offices[0].count
-        count = count / 10 || 0
-        count = Math.ceil(count)
-        if (count === 0) {
-          count = 1
-        }
-        this.offices = offices
-        this.area = area
-        this.prefecture = prefecture
-        this.cities = cities
-        this.keywords = keywords
-        this.postCodes = postCodes
-        this.selectedList = selectedList
-        this.count = count
-        this.page = page
-        this.searchWind = searchWind
-        this.searchIcon = searchIcon
-      } catch (error) {
-        // リロードして消えるようだったら有効化 console.log(error)
-        // console.log(error)
-        return error
-      }
-    },
     areaSearching(query) {
       const prefecture = query.prefecture
       const cities = query.cities

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -17,23 +17,16 @@ const authError422and401 = function (store, error) {
   }
 }
 
-const windowObjectUndefined = function () {
-  return typeof window === 'undefined'
-}
-
-const setAuthInfoToHeader = function (config) {
-  if (!windowObjectUndefined()) {
-    const client = window.localStorage.client
-    const accessToken = window.localStorage.getItem('access-token')
-    const uid = window.localStorage.uid
-    const expiry = window.localStorage.expiry
-    if (client && accessToken && uid && expiry) {
-      config.headers.client = window.localStorage.client
-      config.headers['access-token'] =
-        window.localStorage.getItem('access-token')
-      config.headers.uid = window.localStorage.uid
-      config.headers.expiry = window.localStorage.expiry
-    }
+const setAuthInfoToHeader = function (config, store) {
+  const client = store.state.client
+  const accessToken = store.state.accessToken
+  const uid = store.state.uid
+  const expiry = store.state.expiry
+  if (client && accessToken && uid && expiry) {
+    config.headers.client = client
+    config.headers['access-token'] = accessToken
+    config.headers.uid = uid
+    config.headers.expiry = expiry
   }
 }
 
@@ -55,7 +48,7 @@ const error500 = function (store) {
   store.commit('catchErrorMsg/setMsg', msg)
 }
 
-const setAuthInfoToLocalStorage = function (response) {
+const setAuthInfoToStore = function (response, store) {
   // TODO メソッドの名前が適切でないかも、ログイン処理が成功したらみたいなのがほしい
   const headers = response.headers
   if (headers.office_data) {
@@ -67,11 +60,11 @@ const setAuthInfoToLocalStorage = function (response) {
     headers.expiry &&
     headers['access-token']
   ) {
-    // TODO ログイン処理が成功したら、localstorageに保存されるというのを表現する
-    localStorage.setItem('access-token', headers['access-token'])
-    localStorage.setItem('client', headers.client)
-    localStorage.setItem('uid', headers.uid)
-    localStorage.setItem('expiry', headers.expiry)
+    // TODO ログイン処理が成功したら、vuexに保存されるというのを表現する
+    store.commit('setAccessToken', headers['access-token'])
+    store.commit('setClient', headers.client)
+    store.commit('setUid', headers.uid)
+    store.commit('setExpiry', headers.expiry)
   }
 }
 
@@ -84,10 +77,10 @@ export default function ({ $axios, store }) {
 
   $axios.onResponse((response) => {
     store.commit('catchErrorMsg/clearMsg')
-    setAuthInfoToLocalStorage(response)
+    setAuthInfoToStore(response, store)
   })
 
   $axios.onRequest((config) => {
-    setAuthInfoToHeader(config)
+    setAuthInfoToHeader(config, store)
   })
 }

--- a/plugins/login.js
+++ b/plugins/login.js
@@ -5,7 +5,7 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
 
   $axios.onRequest((config) => {
     if (config.url === '/login') {
-      setAuthInfoToHeader(config)
+      setAuthInfoToHeader(config, store)
     }
   })
 
@@ -29,9 +29,9 @@ export default function ({ $auth, redirect, store, $axios }, inject) {
   }
 }
 
-function setAuthInfoToHeader(config) {
-  config.headers.client = window.localStorage.client
-  config.headers['access-token'] = window.localStorage.getItem('access-token')
-  config.headers.uid = window.localStorage.uid
-  config.headers.expiry = window.localStorage.expiry
+function setAuthInfoToHeader(config, store) {
+  config.headers.client = store.state.client
+  config.headers['access-token'] = store.state.accessToken
+  config.headers.uid = store.state.uid
+  config.headers.expiry = store.state.expiry
 }

--- a/plugins/logout.js
+++ b/plugins/logout.js
@@ -1,12 +1,11 @@
 export default function ({ $auth, redirect, store }, inject) {
   inject('logout', (logoutInfo) => {
     logout(logoutInfo)
-    // console.log(logoutInfo)
   })
   async function logout(logoutInfo) {
     try {
       const response = await $auth.logout(logoutInfo)
-      authDataDeleteToLocalStorage()
+      authDataDeleteToStore()
       // TODO 成功時にstoreにtype入れ込む
       store.commit('catchErrorMsg/setType', 'success')
       store.commit('catchErrorMsg/setMsg', ['ログアウトしました'])
@@ -19,11 +18,7 @@ export default function ({ $auth, redirect, store }, inject) {
     }
   }
 
-  function authDataDeleteToLocalStorage() {
-    localStorage.removeItem('access-token')
-    localStorage.removeItem('expiry')
-    localStorage.removeItem('client')
-    localStorage.removeItem('uid')
-    localStorage.removeItem('office_data')
+  function authDataDeleteToStore() {
+    store.commit('clearAuthData')
   }
 }

--- a/plugins/persistedstate.js
+++ b/plugins/persistedstate.js
@@ -4,7 +4,8 @@ import cookie from 'cookie'
 
 export default ({ store, req }) => {
   createPersistedState({
-    paths: ['specialist', 'customer'],
+    // 永続化したいstoreのkeyを指定する
+    paths: ['specialist', 'customer', 'client', 'accessToken', 'uid', 'expiry'],
     storage: {
       getItem: (key) => {
         // See https://nuxtjs.org/guide/plugins/#using-process-flags

--- a/store/index.js
+++ b/store/index.js
@@ -1,19 +1,53 @@
-// import createPersistedState from 'vuex-persistedstate'
-
 export const state = () => ({
   specialist: false,
   customer: false,
+  client: '',
+  accessToken: '',
+  uid: '',
+  expiry: '',
 })
+
+// stateの初期値としたい任意のデータを定義する
+function setDefaultState() {
+  return {
+    client: '',
+    accessToken: '',
+    uid: '',
+    expiry: '',
+  }
+}
 
 export const mutations = {
   loginSpecialist(state) {
     state.specialist = true
   },
+
   logoutUser(state) {
     state.specialist = false
     state.customer = false
   },
+
   loginCustomer(state) {
     state.customer = true
+  },
+
+  setClient(state, client) {
+    state.client = client
+  },
+
+  setAccessToken(state, accessToken) {
+    state.accessToken = accessToken
+  },
+
+  setUid(state, uid) {
+    state.uid = uid
+  },
+
+  setExpiry(state, expiry) {
+    state.expiry = expiry
+  },
+
+  clearAuthData(state) {
+    Object.assign(state, setDefaultState())
   },
 }


### PR DESCRIPTION
## やったこと

- ログイン時に、認証情報をlocalStorageに保存していたものを、保存先をVuexに変更
- Vuexに保存した認証情報の永続化
  - リロードしても消えないようにするため。ログアウトをするか、有効期限が切れない限り消えません
- 事業所一覧画面でのAPI通信のタイミングを、asyncDataに戻した
  - VuexのStoreに保存されているデータは、サーバーサイドで取得できるため、asyncDataでもHeadersに認証情報をセットできます
- 予約履歴をasyncDataに移行

- ファイル数がちょっと多いですが、見てほしいところはここです
  - **plugins/~~**
  - **store/index.js**
## やらないこと

- 他の機能のasyncDataへの移行（自分が担当していた機能は随時移行しますが、他の人が担当した機能は担当者が対応お願いします。実際に移行する際には**移行ガイド**をご参照ください）

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/mounted-to-asyncdata
```

### 動作確認
- ログインをする
- 検証ツールのvueからTimelineの中のVuex Mutationsを選択する
- 最後に発火される`areaData/setCurrentPrefecture`を選択する
- accessToken, uid, expiry, clientの4つが保存されていればOK
![image](https://user-images.githubusercontent.com/34031637/180645170-b5b159d7-861f-4aca-94e5-7a3d5ec3bbbf.png)
- ページをリロードしても消えないか確認
- ログアウトをする
- 最後に発火される`logoutUser`を選択
- 4つの認証情報が空（初期値）になっていればOK

- 事業所の検索機能を一通り確認し、画面の動きなどに不具合がないか確認する

## 参考になったサイト
[Vuex の状態を robinvdvleuten/vuex-persistedstate で永続化](https://r17n.page/2020/08/13/vuex-persistedstate/)
[robinvdvleuten/vuex-persistedstate](https://github.com/robinvdvleuten/vuex-persistedstate)
- `this.$nuxt.refresh()`
[$nuxt: The Nuxt helper](https://nuxtjs.org/docs/internals-glossary/$nuxt/)

[Object.assign()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)

## 移行ガイド
- 移行前
```javascript
data() {
    return {
      array: [],
    }
  },
  mounted() {
    this.getAPI()
  },
  methods: {
    async getAPI() {
      try {
        const response = await this.$axios.$get(
          `xxxxx/xxxxx/xxxxx`
        )
    this.array = response
      } catch (error) {
        return error
      }
    },
```
- 移行後
```javascript
async asyncData({ $axios }) {
    try {
      const res = await $axios.$get(`xxxx/xxxx`)
      return {
        array: res
      }
    } catch (error) {
      return error
    }
  },
```