### PR TITLE
閲覧履歴画面作成　登録・更新リクエスト送信

### DIFF
--- a/components/office/officeCard.vue
+++ b/components/office/officeCard.vue
@@ -130,7 +130,10 @@ export default {
   computed: {
     toggleClassByRoute() {
       // localhost:8000以降のパスを取得する
-      return this.$route.path.includes('/bookmarks') ? '' : 355
+      return this.$route.path.includes('/bookmarks') ||
+        this.$route.path.includes('/histories')
+        ? ''
+        : 355
     },
     displayImg() {
       return this.office.image.length > 0

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -22,7 +22,7 @@
                 <div v-if="$auth.loggedIn">
                   <div class="mr-8 d-flex align-center">
                     <NuxtLink
-                      to="#"
+                      to="/histories"
                       class="header-style text-overline mr-5 text-decoration-none"
                       >閲覧履歴</NuxtLink
                     >
@@ -183,7 +183,10 @@
 
         <v-list v-if="$auth.loggedIn" nav dense class="pa-0">
           <v-list-item-group v-model="group">
-            <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20" to="#">
+            <v-list-item
+              class="pa-0 ma-0 px-6 py-4 min-height-20"
+              to="/histories"
+            >
               <v-list-item-title
                 class="text-decoration-none text-body-2 navi-style"
               >

--- a/pages/histories/index.vue
+++ b/pages/histories/index.vue
@@ -1,12 +1,18 @@
 <template>
   <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
     <h3>閲覧履歴</h3>
-    <p class="font-weight-black">{{ conversionStringToOfficeCount }}</p>
-    <v-row class="mt-4">
-      <v-col v-for="(office, index) in offices" :key="index" cols="12" md="6">
-        <officeCard :office="office" />
-      </v-col>
-    </v-row>
+    <div v-if="historiesExist">
+      <p class="font-weight-black">{{ conversionStringToOfficeCount }}</p>
+      <v-row class="mt-4">
+        <v-col v-for="(office, index) in offices" :key="index" cols="12" md="6">
+          <officeCard :office="office" />
+        </v-col>
+      </v-row>
+    </div>
+    <div v-else class="not-histories-comment mt-16">
+      <p class="text-center text-subtitle-1">閲覧履歴はありません</p>
+      <ThankBackLink class="text-center" :text="backText" @movePage="moveTop" />
+    </div>
   </v-col>
 </template>
 
@@ -17,12 +23,8 @@ export default {
   async asyncData({ $axios }) {
     try {
       const res = await $axios.$get(`histories`)
-      let officeCount = 0
-      if (res.length !== 0) {
-        officeCount = res.length
-      }
       return {
-        officeCount,
+        officeCount: res.length,
         offices: res,
       }
     } catch (error) {
@@ -33,10 +35,19 @@ export default {
     conversionStringToOfficeCount() {
       return '最新' + this.officeCount + '件'
     },
+    historiesExist() {
+      return this.officeCount > 0
+    },
+    backText() {
+      return 'ホームケアナビトップに戻る'
+    },
   },
   methods: {
     moveShow(id) {
       this.$router.push({ path: `/offices/${id}` })
+    },
+    moveTop() {
+      this.$router.push('/')
     },
   },
 }
@@ -49,5 +60,9 @@ export default {
 .set-max-layout {
   max-height: 50px;
   line-height: normal;
+}
+
+.not-histories-comment {
+  color: #6d7570;
 }
 </style>

--- a/pages/histories/index.vue
+++ b/pages/histories/index.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-col cols="12" md="8" lg="7" xl="7" class="mx-auto">
+    <h3>閲覧履歴</h3>
+    <p class="font-weight-black">{{ conversionStringToOfficeCount }}</p>
+    <v-row class="mt-4">
+      <v-col v-for="(office, index) in offices" :key="index" cols="12" md="6">
+        <officeCard :office="office" />
+      </v-col>
+    </v-row>
+  </v-col>
+</template>
+
+<script>
+export default {
+  layout: 'application',
+  middleware: 'authentication',
+  async asyncData({ $axios }) {
+    try {
+      const res = await $axios.$get(`histories`)
+      let officeCount = 0
+      if (res.length !== 0) {
+        officeCount = res.length
+      }
+      return {
+        officeCount,
+        offices: res,
+      }
+    } catch (error) {
+      return error
+    }
+  },
+  computed: {
+    conversionStringToOfficeCount() {
+      return '最新' + this.officeCount + '件'
+    },
+  },
+  methods: {
+    moveShow(id) {
+      this.$router.push({ path: `/offices/${id}` })
+    },
+  },
+}
+</script>
+<style scoped>
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.set-max-layout {
+  max-height: 50px;
+  line-height: normal;
+}
+</style>

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -40,10 +40,16 @@ export default {
         officeImages: res.officeImages,
         staffs: res.staffs,
         bookmark: res.bookmark,
+        history: res.history,
       }
     } catch (error) {
       return error
     }
+  },
+  mounted() {
+    this.history === null
+      ? this.submitHistory(this.office.id)
+      : this.updateHistory(this.office.id, this.history.id)
   },
   methods: {
     async submitBookmark(officeId) {
@@ -65,6 +71,24 @@ export default {
           }
         )
         this.$nuxt.refresh()
+      } catch (error) {
+        return error
+      }
+    },
+    async submitHistory(officeId) {
+      try {
+        await this.$axios.$post(`offices/${officeId}/histories`, {
+          office_id: officeId,
+        })
+      } catch (error) {
+        return error
+      }
+    },
+    async updateHistory(officeId, historyId) {
+      try {
+        await this.$axios.$put(`offices/${officeId}/histories/${historyId}`, {
+          office_id: officeId,
+        })
       } catch (error) {
         return error
       }


### PR DESCRIPTION
## やったこと

- 閲覧履歴画面実装
- 事業所詳細画面にアクセスしたときに、登録または更新リクエストの送信

## やらないこと

- ページ間のレイアウトの統一（ヘッダーとページタイトルのマージンの統一）

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/create-history-index-create-update
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/request-create-update-history 

```

### 動作確認 Loom 手順

1. 事業所を検索して、10件くらい事業所にアクセスする
2. ヘッダーから閲覧履歴画面に遷移する
3. 先頭以外の事業所にアクセスする
4. 2を実施
5. 直近で閲覧した事業所が先頭に来ていればOK
6. 閲覧履歴のないユーザーでログインする
7. 2を実施
8. **閲覧履歴はありません**と表示され、リンクからトップページへ遷移することを確認する

### 確認書類

[閲覧履歴 PC版](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/fc523e3e-8cbf-4b94-8e51-7e1f2766dcda)  
[閲覧履歴0件 PC版](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/0aa771bc-64a8-41e1-b6d5-3d935b3bf497)  
[閲覧履歴 SP版](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/6dc3aaca-dc2c-4e73-accc-da7c668453c1)
[閲覧履歴0件 SP版](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/3658e2f6-f8fe-4b18-9aea-fe9ca9760c61)

## 参考になったサイト

なし