### PR TITLE
ケアマネ側お礼一覧画面作成　削除機能実装

### DIFF
--- a/components/thank/cardForOffice.vue
+++ b/components/thank/cardForOffice.vue
@@ -64,9 +64,6 @@ export default {
     ReadThank() {
       return this.thank
     },
-    ReadStaff() {
-      return this.ReadThank.staff
-    },
     updateDate() {
       return this.ReadThank.created_at
     },

--- a/components/thank/cardForOffice.vue
+++ b/components/thank/cardForOffice.vue
@@ -2,18 +2,49 @@
   <v-card outlined class="thank-card px-2 pt-3 pb-4">
     <div class="thank-comment-wrapper">
       <div class="d-flex justify-space-between">
-        <p class="mb-0 font-weight-black text-body-2">{{ ReadStaff.name }}</p>
+        <p class="mb-0 font-weight-black text-body-1">
+          {{ ReadThank.name }}&nbsp;&nbsp;({{ ReadThank.age }})
+        </p>
         <p>
           <font :color="gray">{{ updateDate | created_at }}</font>
         </p>
       </div>
       <div class="thank-comment mb-4">
-        <p class="mb-0 text-caption">{{ ReadThank.comments }}</p>
+        <p class="mb-0 text-caption font-color-gray">
+          {{ ReadThank.comments }}
+        </p>
       </div>
     </div>
-    <v-btn block outlined height="40" :color="lightGray" @click="deleteThank"
-      ><font class="font-weight-black" :color="yellow">削除</font></v-btn
-    >
+    <v-dialog v-model="dialog" persistent max-width="300">
+      <template #activator="{ on, attrs }">
+        <v-btn
+          block
+          outlined
+          height="40"
+          :color="lightGray"
+          v-bind="attrs"
+          v-on="on"
+          ><font class="font-weight-black" :color="yellow">削除</font>
+        </v-btn>
+      </template>
+      <v-card class="pa-3 pt-10">
+        <p class="text-center mb-8">本当に削除してもよろしいですか？</p>
+        <v-row dense>
+          <v-col cols="5" @click="dialog = false">
+            <v-btn block outlined :color="lightGray"
+              ><font class="font-weight-black" :color="yellow"
+                >キャンセル</font
+              ></v-btn
+            >
+          </v-col>
+          <v-col cols="7">
+            <v-btn block outlined class="warning" @click="deleteThank"
+              ><font class="font-weight-black" color="white">OK</font></v-btn
+            >
+          </v-col>
+        </v-row>
+      </v-card>
+    </v-dialog>
   </v-card>
 </template>
 <script>
@@ -23,6 +54,11 @@ export default {
       type: Object,
       default: null,
     },
+  },
+  data() {
+    return {
+      dialog: false,
+    }
   },
   computed: {
     ReadThank() {
@@ -65,5 +101,9 @@ export default {
 
 .thank-card {
   border: 0;
+}
+
+.font-color-gray {
+  color: #6d7570;
 }
 </style>

--- a/components/thank/cardForOffice.vue
+++ b/components/thank/cardForOffice.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-card outlined class="thank-card px-2 pt-3 pb-4">
+    <div class="thank-comment-wrapper">
+      <div class="d-flex justify-space-between">
+        <p class="mb-0 font-weight-black text-body-2">{{ ReadStaff.name }}</p>
+        <p>
+          <font :color="gray">{{ updateDate | created_at }}</font>
+        </p>
+      </div>
+      <div class="thank-comment mb-4">
+        <p class="mb-0 text-caption">{{ ReadThank.comments }}</p>
+      </div>
+    </div>
+    <v-btn block outlined height="40" :color="lightGray" @click="deleteThank"
+      ><font class="font-weight-black" :color="yellow">削除</font></v-btn
+    >
+  </v-card>
+</template>
+<script>
+export default {
+  props: {
+    thank: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    ReadThank() {
+      return this.thank
+    },
+    ReadStaff() {
+      return this.ReadThank.staff
+    },
+    updateDate() {
+      return this.ReadThank.created_at
+    },
+    gray() {
+      return '#6D7570'
+    },
+    yellow() {
+      return '#F09C3C'
+    },
+    lightGray() {
+      return '#D9DEDE'
+    },
+  },
+  methods: {
+    async deleteThank() {
+      const id = this.ReadThank.id
+      try {
+        await this.$axios.$delete(`specialists/offices/thanks/${id}`)
+        this.$emit('refresh')
+      } catch (error) {
+        // console.log(error)
+        return error
+      }
+    },
+  },
+}
+</script>
+<style scoped>
+.thank-comment {
+  height: 80px;
+}
+
+.thank-card {
+  border: 0;
+}
+</style>

--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -69,7 +69,7 @@
                                 スタッフ情報</v-list-item-title
                               >
                             </v-list-item>
-                            <v-list-item to="#">
+                            <v-list-item to="/specialists/office/thanks">
                               <v-list-item-title
                                 class="header-style text-overline text-decoration-none mr-5"
                               >
@@ -302,7 +302,10 @@
                 </v-list-item-icon>
               </v-list-item>
               <v-divider color="#D9DEDE"></v-divider>
-              <v-list-item class="pa-0 ma-0 px-6 py-4 min-height-20" to="#">
+              <v-list-item
+                class="pa-0 ma-0 px-6 py-4 min-height-20"
+                to="/specialists/office/thanks"
+              >
                 <v-list-item-title
                   class="text-decoration-none text-body-2 navi-style"
                 >

--- a/pages/specialists/office/thanks/index.vue
+++ b/pages/specialists/office/thanks/index.vue
@@ -59,7 +59,40 @@ export default {
       return '予約状況に戻る'
     },
   },
+  watch: {
+    page() {
+      this.getThanks(this.page)
+      this.scrollTop()
+      this.$router.push({
+        path: `/specialists/office/thanks`,
+        query: {
+          page: this.page,
+        },
+      })
+    },
+  },
   methods: {
+    async getThanks(page = 1) {
+      try {
+        const offsetPage = page - 1
+        const res = await this.$axios.$get(
+          `specialists/offices/thanks?page=${offsetPage}`
+        )
+        this.thanks = res.thanks
+        let count = res.thank_total
+        count = count / 10 || 0
+        count = Math.ceil(count)
+        if (count === 0) {
+          count = 1
+        }
+        this.count = count
+      } catch (error) {
+        return error
+      }
+    },
+    scrollTop() {
+      this.$vuetify.goTo(0)
+    },
     moveTop() {
       this.$router.push('/specialists/office/appointments')
     },
@@ -108,7 +141,7 @@ export default {
 }
 
 ::v-deep i.v-icon.notranslate.mdi {
-  color: #f06364;
+  color: #ff9800;
 }
 /* stylelint-enable */
 </style>

--- a/pages/specialists/office/thanks/index.vue
+++ b/pages/specialists/office/thanks/index.vue
@@ -1,0 +1,114 @@
+<template>
+  <v-container class="base-width">
+    <v-card outlined class="cards-wrapper">
+      <v-card-title class="text-h6 font-weight-black pl-0"
+        >お礼一覧
+      </v-card-title>
+      <v-row v-if="thanksExist">
+        <v-col v-for="thank in thanks" :key="thank.id" cols="12" md="6">
+          <ThankCardForOffice :thank="thank" @refresh="refresh" />
+        </v-col>
+        <v-col cols="12">
+          <v-pagination
+            v-model="page"
+            :length="count"
+            color="#D9DEDE"
+            class="page-nation"
+          ></v-pagination>
+        </v-col>
+      </v-row>
+      <div v-else class="not-thanks-comment mt-16">
+        <p class="text-center text-subtitle-1">お礼投稿履歴はありません</p>
+        <ThankBackLink
+          class="text-center"
+          :text="backText"
+          @movePage="moveTop"
+        />
+      </div>
+    </v-card>
+  </v-container>
+</template>
+<script>
+export default {
+  layout: 'application_specialists',
+  async asyncData({ $axios, query }) {
+    const page = Number(query.page) || 1
+    const offsetPage = page - 1
+    try {
+      const res = await $axios.$get(
+        `specialists/offices/thanks?page=${offsetPage}`
+      )
+      const thanks = res.thanks
+      let count = res.thank_total
+      count = count / 10 || 0
+      count = Math.ceil(count)
+      if (count === 0) {
+        count = 1
+      }
+      return { page, thanks, count }
+    } catch (error) {
+      // console.log(error)
+      return error
+    }
+  },
+  computed: {
+    thanksExist() {
+      return this.thanks.length > 0
+    },
+    backText() {
+      return '予約状況に戻る'
+    },
+  },
+  methods: {
+    moveTop() {
+      this.$router.push('/specialists/office/appointments')
+    },
+    refresh() {
+      if (this.thanks.length <= 2) {
+        this.$router.push({ query: { page: this.page - 1 } })
+      }
+      this.$nuxt.refresh()
+    },
+  },
+}
+</script>
+<style scoped>
+.base-width {
+  max-width: 990px;
+}
+
+.cards-wrapper {
+  border: 0;
+  background-color: #f5f7f7;
+}
+
+.not-thanks-comment {
+  color: #6d7570;
+}
+
+/* stylelint-disable */
+.loading-element {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+}
+
+::v-deep button.v-pagination__navigation {
+  box-shadow: none;
+  border: 1px solid #d9dede;
+}
+
+::v-deep button.v-pagination__item {
+  box-shadow: none;
+  border: 1px solid #d9dede;
+}
+
+::v-deep i.v-icon.notranslate.mdi {
+  color: #f06364;
+}
+/* stylelint-enable */
+</style>


### PR DESCRIPTION
## やったこと

- ケアマネ側お礼一覧ページ作成
  - お礼テーブル内の利用者名と年齢を表示
  - 削除時に表示させる確認ダイアログ実装
## やらないこと

- ケアマネ側のすべての削除機能をモーダルからダイアログへの移行

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/specialist-thanks-list
```
- プルリクはこちら
https://github.com/koki-takishita/home-care-navi-api/pull/117

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/specialist-thanks-list
```

### 動作確認 Loom 手順

- ヘッダーからお礼一覧にアクセス
- 削除ボタン押す
  - キャンセル押す → 削除されない
  - OK押す → 削除される
- お礼が1件もない場合は、**お礼投稿履歴はありません**と表示される

### 確認書類

[ケアマネ側お礼一覧 PC版](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/266cf307-23f2-4742-b3e0-a8fc55fda3fc/)  
[ケアマネ側お礼一覧 SP版](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/5aa105df-92b0-4073-a2dc-d227e37846e8/specs/)

## 参考になったサイト

なし
