### PR TITLE
パスワードリセット機能

### DIFF
--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -1,0 +1,102 @@
+<template>
+  <v-form ref="form" v-model="valid">
+    <label class="font-color-gray font-weight-black text-caption"
+      >パスワード
+      <v-text-field
+        id="email"
+        v-model="Password"
+        class="mt-2 font-weight-regular"
+        outlined
+        dense
+        type="password"
+        height="44"
+        :rules="[
+          formValidates.required,
+          formValidates.typeCheckString,
+          formValidates.password,
+        ]"
+    /></label>
+
+    <label class="font-color-gray font-weight-black text-caption"
+      >パスワード確認
+      <v-text-field
+        id="email"
+        v-model="PasswordConfirmation"
+        class="mt-2 font-weight-regular"
+        outlined
+        dense
+        type="password"
+        height="44"
+        :rules="[
+          formValidates.required,
+          formValidates.typeCheckString,
+          formValidates.confirmCheck,
+        ]"
+    /></label>
+
+    <v-btn block :color="BtnColor" :disabled="!valid" @click="clickResetBtn"
+      >パスワードをリセットする
+    </v-btn>
+  </v-form>
+</template>
+<script>
+export default {
+  props: {
+    password: {
+      type: String,
+      default: null,
+    },
+    passwordConfirmation: {
+      type: String,
+      default: null,
+    },
+    btnColor: {
+      type: String,
+      default: 'error',
+    },
+  },
+  data() {
+    return {
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        typeCheckString: (value) => {
+          const format = /^[a-zA-Z0-9]+$/g
+          return format.test(value) || '入力できるのは半角英数字のみです'
+        },
+        password: (value) =>
+          (value.length >= 8 && value.length <= 16) ||
+          '8文字以上16文字未満で入力してください',
+        confirmCheck: (value) =>
+          value === this.Password || 'パスワードが一致しません',
+      },
+      valid: false,
+    }
+  },
+  computed: {
+    Password: {
+      get() {
+        return this.password
+      },
+      set(Password) {
+        this.$emit('update:password', Password)
+      },
+    },
+    PasswordConfirmation: {
+      get() {
+        return this.passwordConfirmation
+      },
+      set(PasswordConfirmation) {
+        this.$emit('update:passwordConfirmation', PasswordConfirmation)
+      },
+    },
+    BtnColor() {
+      return this.btnColor
+    },
+  },
+  methods: {
+    clickResetBtn() {
+      this.$emit('clickResetBtn')
+    },
+  },
+}
+</script>

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-form ref="form" v-model="valid">
+    <label class="font-color-gray font-weight-black text-caption"
+      >メールアドレス
+      <v-text-field
+        id="email"
+        v-model="Email"
+        class="mt-2 font-weight-regular"
+        outlined
+        dense
+        placeholder="例) homecarenavi@mail.com"
+        type="email"
+        height="44"
+        :rules="[formValidates.required, formValidates.email]"
+    /></label>
+    <v-btn block :color="BtnColor" :disabled="!valid" @click="clickResetBtn"
+      >パスワードをリセットする
+    </v-btn>
+  </v-form>
+</template>
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: null,
+    },
+    btnColor: {
+      type: String,
+      default: 'error',
+    },
+  },
+  data() {
+    return {
+      formValidates: {
+        required: (value) => !!value || '必須項目です',
+        email: (value) => {
+          const format =
+            // eslint-disable-next-line no-control-regex
+            /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
+          return format.test(value) || '正しいメールアドレスを入力してください'
+        },
+      },
+      valid: false,
+    }
+  },
+  computed: {
+    Email: {
+      get() {
+        return this.value
+      },
+      set(Email) {
+        this.$emit('input', Email)
+      },
+    },
+    BtnColor() {
+      return this.btnColor
+    },
+  },
+  methods: {
+    clickResetBtn() {
+      this.$emit('clickResetBtn')
+    },
+  },
+}
+</script>

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -1,0 +1,8 @@
+<template>
+  <h1>送ったよ</h1>
+</template>
+<script>
+export default {
+  layout: 'application',
+}
+</script>

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -12,6 +12,7 @@ export default async function ({ $auth, store, redirect, route }) {
     '/users/new',
     '/users/send',
     '/reset-passwords',
+    '/reset-passwords/edit',
     '/',
   ]
   if (

--- a/middleware/authenticateCustomer.js
+++ b/middleware/authenticateCustomer.js
@@ -11,6 +11,7 @@ export default async function ({ $auth, store, redirect, route }) {
     '/users/contacts/success',
     '/users/new',
     '/users/send',
+    '/reset-passwords',
     '/',
   ]
   if (

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -27,6 +27,7 @@ export default {
         this.$router.push('/users/login')
       } catch (error) {
         // console.log(error)
+        this.$router.push('/reset-passwords')
         return error
       }
     },

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-container class="base-width">
+    <resetPasswordsEdit
+      :password.sync="password"
+      :password-confirmation.sync="passwordConfirmation"
+      @clickResetBtn="resetPassword"
+    />
+  </v-container>
+</template>
+<script>
+export default {
+  layout: 'application',
+  data() {
+    return {
+      password: '',
+      passwordConfirmation: '',
+    }
+  },
+  methods: {
+    async resetPassword() {
+      try {
+        await this.$axios.$put(`customer/password`, {
+          password: this.password,
+          password_confirmation: this.passwordConfirmation,
+        })
+        // TODO layoutによって切り替え
+        this.$router.push('/users/login')
+      } catch (error) {
+        // console.log(error)
+        return error
+      }
+    },
+  },
+}
+</script>
+<style scoped>
+.base-width {
+  max-width: 990px;
+}
+</style>

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-container class="base-width">
+    <v-stepper v-model="e1">
+      <v-stepper-items>
+        <v-stepper-content step="1">
+          <resetPasswordsNew
+            v-model="email"
+            @clickResetBtn="applyForPasswordReset"
+          />
+        </v-stepper-content>
+        <v-stepper-content step="2">
+          <resetPasswordsSend />
+        </v-stepper-content>
+      </v-stepper-items>
+    </v-stepper>
+  </v-container>
+</template>
+<script>
+export default {
+  layout: 'application',
+  data() {
+    return {
+      e1: 1,
+      email: null,
+    }
+  },
+  methods: {
+    async applyForPasswordReset() {
+      // TODO 環境によって切り替える 環境変数で行う
+      // https://github.com/nuxt-community/dotenv-module
+      const redirectUrl = 'http://localhost:8000/reset-passwords/edit'
+      try {
+        await this.$axios.$post(`customer/password`, {
+          email: this.email,
+          redirect_url: redirectUrl,
+        })
+        this.e1 = 2
+      } catch (error) {
+        // emailがデータベースに存在しない時に404エラーになる
+        // emailが存在しないことを確かめられないように
+        // 404エラーの時は成功したように装う
+        if (error.response.status === 404) {
+          this.e1 = 2
+        } else {
+          return error
+        }
+      }
+    },
+  },
+}
+</script>
+<style scoped>
+.base-width {
+  max-width: 990px;
+}
+</style>

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -63,7 +63,7 @@
 
           <p class="ma-0 text-right mt-n3 mb-7">
             <NuxtLink
-              to="#"
+              to="/reset-passwords"
               class="text-overline text-decoration-none font-color-gray"
               >パスワードを忘れた</NuxtLink
             >


### PR DESCRIPTION
## やったこと

- カスタマー側パスワードリセット機能

## やらないこと

1. スタイリング
2. 失敗した時のフラッシュメッセージ 予定(パスワードリセットに失敗しました。もう一度お試しください)

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/reset-password
```

### Front 側

- fetch and checkout
https://github.com/koki-takishita/home-care-navi-api/pull/118
```ruby
git fetch && git checkout origin/feature/reset-password
```

### 動作確認 Loom 手順

1. ログインページからパスワードリセット申請ページへ遷移
2. メールが送られてくる
3. 新しいパスワードを入力する
4. 成功するとログインページへリダイレクトする
5. 新しいパスワードでログインできる
  [手順動画](https://www.loom.com/share/70a94eddfe24472bad9cd6c494db8f47)
6. urlの一部を書き換えると失敗して、パスワード申請画面へ遷移することを確認する
- `access-token`を書き換えてエンター
[わざと失敗させる](https://www.loom.com/share/3ebe6d31e61442de885ebd1aaeb813b1)

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト

[パスワードリセットフロー](https://devise-token-auth.gitbook.io/devise-token-auth/usage/reset_password)
