### PR TITLE
パスワードリセット画面スタイリング

### DIFF
--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -1,43 +1,51 @@
 <template>
-  <v-form ref="form" v-model="valid">
-    <label class="font-color-gray font-weight-black text-caption"
-      >パスワード
-      <v-text-field
-        id="email"
-        v-model="Password"
-        class="mt-2 font-weight-regular"
-        outlined
-        dense
-        type="password"
-        height="44"
-        :rules="[
-          formValidates.required,
-          formValidates.typeCheckString,
-          formValidates.password,
-        ]"
-    /></label>
+  <v-card class="pt-8 pb-16 reset-password-card" outlined>
+    <v-form ref="form" v-model="valid" class="reset-password-form mx-auto">
+      <label class="font-color-gray font-weight-black text-caption"
+        ><font color="gray">パスワード</font>
+        <v-text-field
+          id="email"
+          v-model="Password"
+          class="mt-2 font-weight-regular"
+          outlined
+          dense
+          type="password"
+          height="44"
+          :rules="[
+            formValidates.required,
+            formValidates.typeCheckString,
+            formValidates.password,
+          ]"
+      /></label>
 
-    <label class="font-color-gray font-weight-black text-caption"
-      >パスワード確認
-      <v-text-field
-        id="email"
-        v-model="PasswordConfirmation"
-        class="mt-2 font-weight-regular"
-        outlined
-        dense
-        type="password"
-        height="44"
-        :rules="[
-          formValidates.required,
-          formValidates.typeCheckString,
-          formValidates.confirmCheck,
-        ]"
-    /></label>
-
-    <v-btn block :color="BtnColor" :disabled="!valid" @click="clickResetBtn"
-      >パスワードをリセットする
-    </v-btn>
-  </v-form>
+      <label class="font-color-gray font-weight-black text-caption"
+        ><font color="gray">パスワード確認</font>
+        <v-text-field
+          id="email"
+          v-model="PasswordConfirmation"
+          class="mt-2 font-weight-regular"
+          outlined
+          dense
+          type="password"
+          height="44"
+          :rules="[
+            formValidates.required,
+            formValidates.typeCheckString,
+            formValidates.confirmCheck,
+          ]"
+      /></label>
+      <v-btn
+        block
+        :color="BtnColor"
+        :disabled="!valid"
+        height="60"
+        class="text-h6 font-weight-black"
+        @click="clickResetBtn"
+        >パスワードをリセットする
+      </v-btn>
+      <ThankBackLink :text="textLink" class="text-center" @movePage="goTop" />
+    </v-form>
+  </v-card>
 </template>
 <script>
 export default {
@@ -92,11 +100,35 @@ export default {
     BtnColor() {
       return this.btnColor
     },
+    textLink() {
+      return 'リセットせずにもどる'
+    },
+    gray() {
+      return '#6D7570'
+    },
   },
   methods: {
     clickResetBtn() {
       this.$emit('clickResetBtn')
     },
+    goTop() {
+      this.$router.push('/')
+    },
   },
 }
 </script>
+<style scoped>
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+/* stylelint-enable */
+
+.reset-password-form {
+  max-width: 520px;
+}
+
+.reset-password-card {
+  border: 0;
+}
+</style>

--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -1,6 +1,7 @@
 <template>
   <v-card class="pt-8 pb-16 reset-password-card" outlined>
     <v-form ref="form" v-model="valid" class="reset-password-form mx-auto">
+      <p :class="titleClass">パスワード再設定</p>
       <label class="font-color-gray font-weight-black text-caption"
         ><font color="gray">パスワード</font>
         <v-text-field
@@ -105,6 +106,16 @@ export default {
     },
     gray() {
       return '#6D7570'
+    },
+    titleClass() {
+      if (this.isMobile) {
+        return 'text-left text-h6 font-weight-black mb-10'
+      } else {
+        return 'text-center text-h6 font-weight-black mb-10'
+      }
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.smAndDown
     },
   },
   methods: {

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -23,7 +23,7 @@
       depressed
       @click="clickResetBtn"
     >
-      パスワードをリセットする</v-btn
+      次にすすむ</v-btn
     >
     <ThankBackLink :text="backText" class="text-center" @movePage="goTop" />
   </v-form>

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -1,8 +1,6 @@
 <template>
   <v-form ref="form" v-model="valid" class="rest-password-card mx-auto">
-    <p class="text-center text-h6 font-weight-black mb-10">
-      パスワードのリセット
-    </p>
+    <p :class="titleClass">パスワードのリセット</p>
     <label class="font-color-gray font-weight-black text-caption"
       ><font :color="gray">メールアドレス</font>
       <v-text-field
@@ -22,8 +20,8 @@
       :disabled="!valid"
       height="60"
       class="font-weight-black text-h6"
-      @click="clickResetBtn"
       depressed
+      @click="clickResetBtn"
     >
       パスワードをリセットする</v-btn
     >
@@ -73,6 +71,17 @@ export default {
     },
     gray() {
       return '#6D7570'
+    },
+    // breakpointで中央揃え、左揃えに切り替える
+    titleClass() {
+      if (this.isMobile) {
+        return 'text-left text-h6 font-weight-black mb-10'
+      } else {
+        return 'text-center text-h6 font-weight-black mb-10'
+      }
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.smAndDown
     },
   },
   methods: {

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -1,7 +1,10 @@
 <template>
-  <v-form ref="form" v-model="valid">
+  <v-form ref="form" v-model="valid" class="rest-password-card mx-auto">
+    <p class="text-center text-h6 font-weight-black mb-10">
+      パスワードのリセット
+    </p>
     <label class="font-color-gray font-weight-black text-caption"
-      >メールアドレス
+      ><font :color="gray">メールアドレス</font>
       <v-text-field
         id="email"
         v-model="Email"
@@ -13,9 +16,18 @@
         height="44"
         :rules="[formValidates.required, formValidates.email]"
     /></label>
-    <v-btn block :color="BtnColor" :disabled="!valid" @click="clickResetBtn"
-      >パスワードをリセットする
-    </v-btn>
+    <v-btn
+      block
+      :color="BtnColor"
+      :disabled="!valid"
+      height="60"
+      class="font-weight-black text-h6"
+      @click="clickResetBtn"
+      depressed
+    >
+      パスワードをリセットする</v-btn
+    >
+    <ThankBackLink :text="backText" class="text-center" @movePage="goTop" />
   </v-form>
 </template>
 <script>
@@ -56,11 +68,35 @@ export default {
     BtnColor() {
       return this.btnColor
     },
+    backText() {
+      return 'リセットせずにもどる'
+    },
+    gray() {
+      return '#6D7570'
+    },
   },
   methods: {
     clickResetBtn() {
       this.$emit('clickResetBtn')
     },
+    goTop() {
+      this.$router.push('/')
+    },
   },
 }
 </script>
+<style scoped>
+/* stylelint-disable */
+.v-text-field--outlined >>> fieldset {
+  border-color: #d9dede;
+}
+
+::v-deep input::placeholder {
+  color: #d9dede !important;
+}
+/* stylelint-enable */
+
+.rest-password-card {
+  max-width: 520px;
+}
+</style>

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -1,8 +1,40 @@
 <template>
-  <h1>送ったよ</h1>
+  <div class="send-card mx-auto">
+    <p :class="titleClass">パスワードのリセット完了</p>
+    <v-card-text class="text-center pt-0">
+      入力いただいたメールアドレスに<br />新しいパスワードを送付いたしました。
+    </v-card-text>
+    <ThankBackLink class="text-center" :text="linkText" @movePage="goTop" />
+  </div>
 </template>
 <script>
 export default {
   layout: 'application',
+  computed: {
+    linkText() {
+      return 'ホームケアナビトップにもどる'
+    },
+    // breakpointで中央揃え、左揃えに切り替える
+    titleClass() {
+      if (this.isMobile) {
+        return 'text-left text-h6 font-weight-black mb-10'
+      } else {
+        return 'text-center text-h6 font-weight-black mb-10'
+      }
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.smAndDown
+    },
+  },
+  methods: {
+    goTop() {
+      this.$router.push('/')
+    },
+  },
 }
 </script>
+<style scoped>
+.send-card {
+  max-width: 520px;
+}
+</style>

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -2,7 +2,7 @@
   <div class="send-card mx-auto">
     <p :class="titleClass">パスワードのリセット完了</p>
     <v-card-text class="text-center pt-0">
-      入力いただいたメールアドレスに<br />新しいパスワードを送付いたしました。
+      確認メールを送付しました。<br />リンクをクリックして新しいパスワードを設定してください。
     </v-card-text>
     <ThankBackLink class="text-center" :text="linkText" @movePage="goTop" />
   </div>

--- a/components/thank/backLink.vue
+++ b/components/thank/backLink.vue
@@ -30,6 +30,10 @@ export default {
       type: Number,
       default: 2,
     },
+    color: {
+      type: String,
+      default: '#F06364',
+    },
   },
   computed: {
     id() {
@@ -39,7 +43,7 @@ export default {
       return this.text
     },
     linkColor() {
-      return '#F06364'
+      return this.color
     },
     iconFlag() {
       return this.icon

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -36,6 +36,6 @@ export default {
 </script>
 <style scoped>
 .base-width {
-  max-width: 990px;
+  max-width: 750px;
 }
 </style>

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-container class="base-width">
-    <v-stepper v-model="e1">
+  <v-container class="base-width pa-0">
+    <v-stepper v-model="e1" outlined class="reset-password-card">
       <v-stepper-items>
-        <v-stepper-content step="1">
+        <v-stepper-content step="1" class="pb-16">
           <resetPasswordsNew
             v-model="email"
             @clickResetBtn="applyForPasswordReset"
@@ -51,6 +51,10 @@ export default {
 </script>
 <style scoped>
 .base-width {
-  max-width: 990px;
+  max-width: 750px;
+}
+
+.reset-password-card {
+  border: 0;
 }
 </style>

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -2,13 +2,13 @@
   <v-container class="base-width pa-0">
     <v-stepper v-model="e1" outlined class="reset-password-card">
       <v-stepper-items>
-        <v-stepper-content step="1" class="pb-16">
+        <v-stepper-content step="1" class="pb-16 pt-8">
           <resetPasswordsNew
             v-model="email"
             @clickResetBtn="applyForPasswordReset"
           />
         </v-stepper-content>
-        <v-stepper-content step="2">
+        <v-stepper-content step="2" class="pb-16 pt-8">
           <resetPasswordsSend />
         </v-stepper-content>
       </v-stepper-items>


### PR DESCRIPTION
## やったこと

- パスワードリセット画面のスタイリング

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/password-rest-form-style
```

### 動作確認  ※ パスワードリセット(機能のみ)のプルリクと混じっています。
- パスワードリセットが問題なく行えるか？
https://github.com/koki-takishita/home-care-navi-front/pull/230
- xdの画面図と大差がないか？
※ パスワードリセット申請画面の文言 パスワードリセットする → 次に進むに変更(amazonのパスワードリセット参考)
[![Image from Gyazo](https://i.gyazo.com/71aa606cda3d21d98a6283e6d6cdb0ad.png)](https://gyazo.com/71aa606cda3d21d98a6283e6d6cdb0ad)
- xdにない画面図に違和感がないか

### 確認書類

**URL は該当のものに変えること**  
[sp パスワード申請画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/93b8d471-dc5d-4d80-a4ca-f3e26491e688/specs/)  
[sp メール送信後画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/78435fb1-0344-43ea-a044-06a9ec1347b9/specs/)
[pc パスワード申請画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/95598953-a1b2-4e6b-ab7f-60385c4cea91/specs/)
[pc メール送信後画面](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/screen/67fcafff-e2f1-4202-8bdd-15d30b94edf7/specs/)
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト
- なし
