### PR TITLE
パスワードリセット ケアマネ側も対応ver

### DIFF
--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -87,8 +87,8 @@ export default {
           return format.test(value) || '入力できるのは半角英数字のみです'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字未満で入力してください',
         confirmCheck: (value) =>
           value === this.Password || 'パスワードが一致しません',
       },
@@ -143,10 +143,10 @@ export default {
       this.$emit('clickResetBtn')
     },
     goPage() {
-      this.Type === 'specialist' ? this.goAppointment() : this.goTop()
+      this.Type === 'specialist' ? this.goAppointment() : this.goLogin()
     },
-    goTop() {
-      this.$router.push('/')
+    goLogin() {
+      this.$router.push('/users/login')
     },
     goAppointment() {
       this.$router.push('/specialists/login')

--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -49,7 +49,7 @@
         :text="textLink"
         class="text-center"
         :color="TextColor"
-        @movePage="goTop"
+        @movePage="goPage"
       />
     </v-form>
   </v-card>
@@ -72,6 +72,10 @@ export default {
     textColor: {
       type: String,
       default: '#F06364',
+    },
+    type: {
+      type: String,
+      default: 'customer',
     },
   },
   data() {
@@ -120,6 +124,9 @@ export default {
     gray() {
       return '#6D7570'
     },
+    Type() {
+      return this.type
+    },
     titleClass() {
       if (this.isMobile) {
         return 'text-left text-h6 font-weight-black mb-10'
@@ -135,8 +142,14 @@ export default {
     clickResetBtn() {
       this.$emit('clickResetBtn')
     },
+    goPage() {
+      this.Type === 'specialist' ? this.goAppointment() : this.goTop()
+    },
     goTop() {
       this.$router.push('/')
+    },
+    goAppointment() {
+      this.$router.push('/specialists/login')
     },
   },
 }

--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -41,10 +41,16 @@
         :disabled="!valid"
         height="60"
         class="text-h6 font-weight-black"
+        depressed
         @click="clickResetBtn"
         >パスワードをリセットする
       </v-btn>
-      <ThankBackLink :text="textLink" class="text-center" @movePage="goTop" />
+      <ThankBackLink
+        :text="textLink"
+        class="text-center"
+        :color="TextColor"
+        @movePage="goTop"
+      />
     </v-form>
   </v-card>
 </template>
@@ -62,6 +68,10 @@ export default {
     btnColor: {
       type: String,
       default: 'error',
+    },
+    textColor: {
+      type: String,
+      default: '#F06364',
     },
   },
   data() {
@@ -100,6 +110,9 @@ export default {
     },
     BtnColor() {
       return this.btnColor
+    },
+    TextColor() {
+      return this.textColor
     },
     textLink() {
       return 'リセットせずにもどる'

--- a/components/resetPasswords/edit.vue
+++ b/components/resetPasswords/edit.vue
@@ -88,7 +88,7 @@ export default {
         },
         password: (value) =>
           (value.length >= 8 && value.length <= 32) ||
-          '8文字以上32文字未満で入力してください',
+          '8文字以上32文字以下で入力してください',
         confirmCheck: (value) =>
           value === this.Password || 'パスワードが一致しません',
       },

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -25,7 +25,12 @@
     >
       次にすすむ</v-btn
     >
-    <ThankBackLink :text="backText" class="text-center" @movePage="goTop" />
+    <ThankBackLink
+      :text="backText"
+      class="text-center"
+      :color="TextColor"
+      @movePage="goPage"
+    />
   </v-form>
 </template>
 <script>
@@ -38,6 +43,14 @@ export default {
     btnColor: {
       type: String,
       default: 'error',
+    },
+    textColor: {
+      type: String,
+      default: '#F06364',
+    },
+    type: {
+      type: String,
+      default: 'customer',
     },
   },
   data() {
@@ -66,6 +79,12 @@ export default {
     BtnColor() {
       return this.btnColor
     },
+    TextColor() {
+      return this.textColor
+    },
+    Type() {
+      return this.type
+    },
     backText() {
       return 'リセットせずにもどる'
     },
@@ -88,8 +107,14 @@ export default {
     clickResetBtn() {
       this.$emit('clickResetBtn')
     },
+    goPage() {
+      this.Type === 'specialist' ? this.goAppointment() : this.goTop()
+    },
     goTop() {
       this.$router.push('/')
+    },
+    goAppointment() {
+      this.$router.push('specialists/login')
     },
   },
 }

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -108,10 +108,10 @@ export default {
       this.$emit('clickResetBtn')
     },
     goPage() {
-      this.Type === 'specialist' ? this.goAppointment() : this.goTop()
+      this.Type === 'specialist' ? this.goAppointment() : this.goLogin()
     },
-    goTop() {
-      this.$router.push('/')
+    goLogin() {
+      this.$router.push('/users/login')
     },
     goAppointment() {
       this.$router.push('specialists/login')

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -38,7 +38,7 @@ export default {
   props: {
     value: {
       type: String,
-      default: null,
+      default: '',
     },
     btnColor: {
       type: String,

--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -12,7 +12,7 @@
         placeholder="例) homecarenavi@mail.com"
         type="email"
         height="44"
-        :rules="[formValidates.required, formValidates.email]"
+        :rules="[formValidates.required, formValidates.email, formValidates.emailLength]"
     /></label>
     <v-btn
       block
@@ -63,6 +63,7 @@ export default {
             /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
+        emailLength: (value) => value.length <= 255 || 'メールアドレスは255文字以下で入力してください',
       },
       valid: false,
     }

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -54,7 +54,7 @@ export default {
       this.Type === 'specialist' ? this.goAppointment() : this.goTop()
     },
     goTop() {
-      this.$router.push('/')
+      this.$router.push('/users/login')
     },
     goAppointment() {
       this.$router.push('/specialists/login')

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -2,14 +2,31 @@
   <div class="send-card mx-auto">
     <p :class="titleClass">パスワードのリセット完了</p>
     <v-card-text class="text-center pt-0">
-      確認メールを送付しました。<br />リンクをクリックして新しいパスワードを設定してください。
+      <font
+        >確認メールを送付しました。<br />リンクをクリックして新しいパスワードを設定してください。</font
+      >
     </v-card-text>
-    <ThankBackLink class="text-center" :text="linkText" @movePage="goTop" />
+    <ThankBackLink
+      class="text-center"
+      :text="linkText"
+      :color="TextColor"
+      @movePage="goPage"
+    />
   </div>
 </template>
 <script>
 export default {
   layout: 'application',
+  props: {
+    textColor: {
+      type: String,
+      default: '#F06364',
+    },
+    type: {
+      type: String,
+      default: 'customer',
+    },
+  },
   computed: {
     linkText() {
       return 'ホームケアナビトップにもどる'
@@ -25,10 +42,22 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.smAndDown
     },
+    TextColor() {
+      return this.textColor
+    },
+    Type() {
+      return this.type
+    },
   },
   methods: {
+    goPage() {
+      this.Type === 'specialist' ? this.goAppointment() : this.goTop()
+    },
     goTop() {
       this.$router.push('/')
+    },
+    goAppointment() {
+      this.$router.push('/specialists/login')
     },
   },
 }

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -54,7 +54,7 @@ export default {
       this.Type === 'specialist' ? this.goAppointment() : this.goTop()
     },
     goTop() {
-      this.$router.push('/users/login')
+      this.$router.push('/')
     },
     goAppointment() {
       this.$router.push('/specialists/login')

--- a/components/resetPasswords/send.vue
+++ b/components/resetPasswords/send.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="send-card mx-auto">
-    <p :class="titleClass">パスワードのリセット完了</p>
+    <p :class="titleClass">メールの送信完了</p>
     <v-card-text class="text-center pt-0">
       <font
         >確認メールを送付しました。<br />リンクをクリックして新しいパスワードを設定してください。</font

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -3,6 +3,7 @@ export default async function ({ $auth, store, redirect, route }) {
     route.path !== '/specialists/login' &&
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
+    route.path !== '/reset-passwords' &&
     store.state.specialist !== true
   ) {
     await $auth.logout()

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -4,6 +4,7 @@ export default async function ({ $auth, store, redirect, route }) {
     route.path !== '/specialists/users/new' &&
     route.path !== '/specialists/users/send' &&
     route.path !== '/reset-passwords' &&
+    route.path !== '/reset-passwords/edit' &&
     store.state.specialist !== true
   ) {
     await $auth.logout()

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -120,4 +120,8 @@ export default {
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {},
+
+  publicRuntimeConfig: {
+    passwordResetRedirectUrl: process.env.PASSWORD_RESET_REDIRECT_URL,
+  },
 }

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -3,18 +3,56 @@
     <resetPasswordsEdit
       :password.sync="password"
       :password-confirmation.sync="passwordConfirmation"
+      :btn-color="btnColor"
+      :text-color="textColor"
       @clickResetBtn="resetPassword"
     />
   </v-container>
 </template>
 <script>
 export default {
-  layout: 'application',
+  // queryであるtypeの値によってlayoutを切り替える
+  // type = customer -> application
+  // type = specialist -> application/specialists
+  layout(context) {
+    const type = context.query.type
+    let layout
+    switch (type) {
+      case 'customer':
+        layout = 'application'
+        break
+      case 'specialist':
+        layout = 'application_specialists'
+        break
+      default:
+        layout = 'application'
+        break
+    }
+    return layout
+  },
+  asyncData({ query }) {
+    const type = query.type || ''
+    return { type }
+  },
   data() {
     return {
       password: '',
       passwordConfirmation: '',
     }
+  },
+  computed: {
+    btnColor() {
+      return this.type === 'specialist' ? 'warning' : 'error'
+    },
+    textColor() {
+      return this.type === 'specialist' ? this.yellow : this.red
+    },
+    yellow() {
+      return '#F09C3C'
+    },
+    red() {
+      return '#F06364'
+    },
   },
   methods: {
     async resetPassword() {

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -5,6 +5,7 @@
       :password-confirmation.sync="passwordConfirmation"
       :btn-color="btnColor"
       :text-color="textColor"
+      :type="type"
       @clickResetBtn="resetPassword"
     />
   </v-container>

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -57,8 +57,9 @@ export default {
   },
   methods: {
     async resetPassword() {
+      const type = this.type === 'specialist' ? 'specialists/users' : 'customer'
       try {
-        await this.$axios.$put(`customer/password`, {
+        await this.$axios.$put(`${type}/password`, {
           password: this.password,
           password_confirmation: this.passwordConfirmation,
         })

--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -63,12 +63,21 @@ export default {
           password_confirmation: this.passwordConfirmation,
         })
         // TODO layoutによって切り替え
-        this.$router.push('/users/login')
+        this.togglePage()
       } catch (error) {
         // console.log(error)
         this.$router.push('/reset-passwords')
         return error
       }
+    },
+    togglePage() {
+      this.type === 'specialist' ? this.moveSpecialist() : this.moveCustomer()
+    },
+    moveSpecialist() {
+      this.$router.push('/specialists/login')
+    },
+    moveCustomer() {
+      this.$router.push('/users/login')
     },
   },
 }

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -5,6 +5,7 @@
         <v-stepper-content step="1" class="pb-16 pt-8">
           <resetPasswordsNew
             v-model="email"
+            :btn-color="btnColor"
             @clickResetBtn="applyForPasswordReset"
           />
         </v-stepper-content>
@@ -17,12 +18,35 @@
 </template>
 <script>
 export default {
-  layout: 'application',
+  // queryであるtypeの値によってlayoutを切り替える
+  // type = customer -> application
+  // type = specialist -> application/specialists
+  layout(context) {
+    const type = context.query.type
+    let layout
+    switch (type) {
+      case 'customer':
+        layout = 'application'
+        break
+      case 'specialist':
+        layout = 'application_specialists'
+        break
+      default:
+        layout = 'application'
+        break
+    }
+    return layout
+  },
   data() {
     return {
       e1: 1,
       email: null,
     }
+  },
+  computed: {
+    btnColor() {
+      return '#F09C3C'
+    },
   },
   methods: {
     async applyForPasswordReset() {

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -6,11 +6,13 @@
           <resetPasswordsNew
             v-model="email"
             :btn-color="btnColor"
+            :text-color="textColor"
+            :type="type"
             @clickResetBtn="applyForPasswordReset"
           />
         </v-stepper-content>
         <v-stepper-content step="2" class="pb-16 pt-8">
-          <resetPasswordsSend />
+          <resetPasswordsSend :text-color="textColor" :type="type" />
         </v-stepper-content>
       </v-stepper-items>
     </v-stepper>
@@ -37,6 +39,18 @@ export default {
     }
     return layout
   },
+  asyncData({ $config, query }) {
+    const envRedirectUrl = $config.passwordResetRedirectUrl
+    const type = query.type || ''
+
+    // queryであるtypeの値によってredirectQueryを切り替える
+    // type = customer -> customer
+    // type = '' -> customer
+    // type = specialist -> specialist
+    const redirectQuery = type === 'specialist' ? 'specialist' : 'customer'
+    const redirectUrl = `${envRedirectUrl}?type=${redirectQuery}`
+    return { redirectUrl, type }
+  },
   data() {
     return {
       e1: 1,
@@ -45,18 +59,26 @@ export default {
   },
   computed: {
     btnColor() {
+      return this.type === 'specialist' ? 'warning' : 'error'
+    },
+    textColor() {
+      return this.type === 'specialist' ? this.yellow : this.red
+    },
+    yellow() {
       return '#F09C3C'
+    },
+    red() {
+      return '#F06364'
     },
   },
   methods: {
     async applyForPasswordReset() {
       // TODO 環境によって切り替える 環境変数で行う
       // https://github.com/nuxt-community/dotenv-module
-      const redirectUrl = 'http://localhost:8000/reset-passwords/edit'
       try {
         await this.$axios.$post(`customer/password`, {
           email: this.email,
-          redirect_url: redirectUrl,
+          redirect_url: this.redirectUrl,
         })
         this.e1 = 2
       } catch (error) {

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -74,8 +74,6 @@ export default {
   methods: {
     async applyForPasswordReset() {
       const type = this.type === 'specialist' ? 'specialists/users' : 'customer'
-      // TODO 環境によって切り替える 環境変数で行う
-      // https://github.com/nuxt-community/dotenv-module
       try {
         await this.$axios.$post(`${type}/password`, {
           email: this.email,

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -54,7 +54,7 @@ export default {
   data() {
     return {
       e1: 1,
-      email: null,
+      email: '',
     }
   },
   computed: {

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -73,10 +73,11 @@ export default {
   },
   methods: {
     async applyForPasswordReset() {
+      const type = this.type === 'specialist' ? 'specialists/users' : 'customer'
       // TODO 環境によって切り替える 環境変数で行う
       // https://github.com/nuxt-community/dotenv-module
       try {
-        await this.$axios.$post(`customer/password`, {
+        await this.$axios.$post(`${type}/password`, {
           email: this.email,
           redirect_url: this.redirectUrl,
         })

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -61,13 +61,14 @@
               type="password"
           /></label>
 
-          <p class="ma-0 text-right mt-n3 mb-7">
-            <NuxtLink
-              to="#"
-              class="text-overline text-decoration-none font-color-gray"
-              >パスワードを忘れた</NuxtLink
+          <div class="ma-0 text-right mt-n3 mb-6">
+            <p
+              class="text-overline text-decoration-none font-color-gray d-inline-block mb-0 set-z-index"
+              @click="goResetPassword"
             >
-          </p>
+              パスワードを忘れた
+            </p>
+          </div>
 
           <v-card-actions class="pa-0">
             <v-btn
@@ -145,6 +146,14 @@ export default {
       },
     }
   },
+  methods: {
+    goResetPassword() {
+      this.$router.push({
+        path: '/reset-passwords',
+        query: { type: 'specialist' },
+      })
+    },
+  },
 }
 </script>
 <style scoped>
@@ -162,7 +171,13 @@ export default {
 ::v-deep input::placeholder {
   color: #d9dede !important;
 }
+
 .font-color-gray {
   color: #6d7570;
+}
+
+.set-z-index {
+  z-index: 9;
+  cursor: pointer;
 }
 </style>

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -61,13 +61,14 @@
               type="password"
           /></label>
 
-          <p class="ma-0 text-right mt-n3 mb-7">
-            <NuxtLink
-              to="/reset-passwords"
-              class="text-overline text-decoration-none font-color-gray"
-              >パスワードを忘れた</NuxtLink
+          <div class="ma-0 text-right mt-n3 mb-6">
+            <p
+              class="text-overline text-decoration-none font-color-gray d-inline-block mb-0 set-z-index"
+              @click="goResetPassword"
             >
-          </p>
+              パスワードを忘れた
+            </p>
+          </div>
 
           <v-card-actions class="pa-0">
             <v-btn
@@ -145,6 +146,14 @@ export default {
       },
     }
   },
+  methods: {
+    goResetPassword() {
+      this.$router.push({
+        path: '/reset-passwords',
+        query: { type: 'customer' },
+      })
+    },
+  },
 }
 </script>
 <style scoped>
@@ -164,5 +173,10 @@ export default {
 }
 .font-color-gray {
   color: #6d7570;
+}
+
+.set-z-index {
+  z-index: 9;
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
## やったこと

1. ケアマネ側パスワード設定
2. layoutをqueryによって切り替える
3. 環境変数を参照する設定

## やらないこと

- なし

### Api側
- 使用するブランチ
https://github.com/koki-takishita/home-care-navi-api/pull/123

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/toggle-layout
```

### 動作確認 Loom 手順

1. .envファイル作成して、redirect_urlを設定する
```ruby
touch .env

# .envファイル内
 PASSWORD_RESET_REDIRECT_URL='http://localhost:8000/reset-passwords/edit'
```
2. カスタマーのパスワードリセットが正常に行える
[loom手順動画](https://www.loom.com/share/327621bcd3e04af3a2434cbb1f2a7761)
3. ケアマネのパスワードリセットが成就に行える
[loom手順動画](https://www.loom.com/share/c404b030a49b4ebcb984c867c40bd6f7)

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト

[layoutでcontextを使う](https://nuxtjs.org/docs/components-glossary/layout#the-layout-property)
[環境変数](https://qiita.com/taai/items/cbc61b9b4a18aacad57e)