### PR TITLE
スタッフ追加・編集のバリデーション修正

### DIFF
--- a/pages/specialists/office/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/staffs/_staff_id/edit.vue
@@ -117,13 +117,13 @@ export default {
           value.size <= 10000000 ||
           '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
-          value.length <= 31 || '30文字以下で入力してください',
+          value.length <= 30 || '30文字以下で入力してください',
         kanaCheck: (value) => {
           const format = /^[ぁ-んー　 ]*$/ // eslint-disable-line
           return format.test(value) || 'ひらがなで入力してください'
         },
         introductionCountCheck: (value) =>
-          value.length <= 81 || '80文字以下で入力してください',
+          value.length <= 80 || '80文字以下で入力してください',
       },
       staff_id: this.$route.params.staff_id,
       image: null,

--- a/pages/specialists/office/staffs/new.vue
+++ b/pages/specialists/office/staffs/new.vue
@@ -104,13 +104,13 @@ export default {
           value.size <= 10000000 ||
           '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
-          value.length <= 31 || '30文字以下で入力してください',
+          value.length <= 30 || '30文字以下で入力してください',
         kanaCheck: (value) => {
           const format = /^[ぁ-んー　 ]*$/ // eslint-disable-line
           return format.test(value) || 'ひらがなで入力してください'
         },
         introductionCountCheck: (value) =>
-          value.length <= 81 || '80文字以下で入力してください',
+          value.length <= 80 || '80文字以下で入力してください',
       },
       name: '',
       kana: '',


### PR DESCRIPTION
## やったこと

- スタッフ追加・編集画面のバリデーション修正
  - 以下のものを入力するとバリデーションがかかる
    - 31文字以上の名前
    - 31文字以上のふりがな
    - 81文字以上の紹介文

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/staff-validation -> fix/staff-validation
```

### 動作確認 Loom 手順

- **やったこと**に記載の項目についてテストする

### 確認書類
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

なし
