### PR TITLE
予約完了時にローカルストレージ削除

### DIFF
--- a/pages/offices/_id/appointments/confirm.vue
+++ b/pages/offices/_id/appointments/confirm.vue
@@ -127,8 +127,14 @@ export default {
             called_status: 0,
           }
         )
-        this.$router.push('/users/send')
         this.$router.push(`/offices/${this.office_id}/appointments/success`)
+        localStorage.removeItem('appointments.meet_date')
+        localStorage.removeItem('appointments.meet_time')
+        localStorage.removeItem('appointments.name')
+        localStorage.removeItem('appointments.age')
+        localStorage.removeItem('appointments.phone_number')
+        localStorage.removeItem('appointments.comment')
+        localStorage.removeItem('appointments.expiry')
         return response
       } catch (error) {
         return error


### PR DESCRIPTION
## やったこと

- 予約完了時に、ローカルストレージに保存していたフォームデータを削除

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/appointment-completed-delete-localstorage
```

### 動作確認 Loom 手順

- 予約完了時に、ローカルストレージの値が消えているか確認

## 参考になったサイト

なし
