### PR TITLE
入力した電話番号がusersテーブルとofficesテーブルにあればエラーメッセージを表示する

### DIFF
--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -47,11 +47,11 @@
                 v-model="form.email"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
                 outlined
-                :rules="[formValidates.required, formValidates.email]"
                 dense
                 placeholder="例) homecarenavi@mail.com"
                 type="email"
                 height="44"
+                :rules="[formValidates.required, formValidates.email]"
             /></label>
           </div>
 

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -63,14 +63,14 @@
                 v-model="form.password"
                 outlined
                 dense
+                class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
+                type="password"
+                placeholder="半角英数字8文字以上"
                 :rules="[
                   formValidates.required,
                   formValidates.typeCheckString,
                   formValidates.password,
                 ]"
-                class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
-                type="password"
-                placeholder="半角英数字8文字以上"
             /></label>
           </div>
 

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -239,7 +239,7 @@ export default {
     // 被りがあったら、'登録済みの電話番号です。'を表示 エラーメッセージはapiのレスポンスを使用している
     async 'form.phone_number'() {
       // form.phone_numberの値が変化したらだたちにfalseにする
-      // apiとの通信で、結果がNGでも一瞬だけtureになってしまうため
+      // apiとの通信で、結果がNGでも一瞬だけtrueになってしまうため
       this.form.phoneNumberCheck = false
       const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
       if (format.test(this.form.phone_number)) {

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -132,11 +132,11 @@
             <v-text-field
               id="address"
               v-model="form.address"
-              :rules="[formValidates.required]"
               outlined
               dense
               height="44"
               class="address-form set-max-width-520"
+              :rules="[formValidates.required]"
               placeholder="東京都世田谷区祖父谷4-3-15"
             >
             </v-text-field>

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -113,11 +113,11 @@
             <v-text-field
               id="post_code"
               v-model="form.post_code"
-              :rules="[formValidates.required, formValidates.postCode]"
               outlined
               dense
               height="44"
               class="post-form"
+              :rules="[formValidates.required, formValidates.postCode]"
               placeholder="123-4567"
             >
               <template #prepend>

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -246,8 +246,8 @@ export default {
         let msg
 
         // apiへリクエスト
-        // 成功 case 'string'
-        // 失敗 case 'object'
+        // 200 case 'string'
+        // 403 case 'object'
         const res = await this.checkPhoneNumber()
         switch (typeof res) {
           case 'string':

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -99,9 +99,9 @@
               <v-text-field
                 id="phone_number"
                 v-model="form.phone_number"
-                :error-messages="errors"
                 outlined
                 dense
+                :error-messages="errors"
                 placeholder="080-1234-5678"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
                 type="tel"
@@ -147,7 +147,7 @@
               id="send"
               class="error pa-0 text-h6 d-none d-sm-block"
               block
-              :disabled="!form.valid"
+              :disabled="isValid"
               max-width="520"
               min-width="343"
               height="60"
@@ -160,7 +160,7 @@
               id="send"
               class="error pa-0 ma-0 text-h6 d-block d-sm-none"
               block
-              :disabled="!form.valid"
+              :disabled="isValid"
               max-width="520"
               min-width="343"
               height="48"
@@ -189,6 +189,7 @@ export default {
         post_code: '',
         address: '',
         valid: false,
+        phoneNumberCheck: false,
       },
       errors: [],
       formValidates: {
@@ -221,15 +222,37 @@ export default {
       },
     }
   },
+  computed: {
+    // 新規登録ボタン押せる状態   false
+    // 新規登録ボタン押せない状態 true
+    isValid() {
+      // formのバリテーションルールをすべて突破している && 電話番号に被りがない
+      const flag = this.form.valid && this.form.phoneNumberCheck
+
+      // flag = false 新規登録ボタン押せる状態
+      // flag = true  新規登録ボタン押せない状態
+      return !flag
+    },
+  },
   watch: {
+    // form.phene_numberの値がusersテーブルとofficesテーブルの被りがないかチェック
+    // 被りがあったら、'登録済みの電話番号です。'を表示 エラーメッセージはapiのレスポンスを使用している
     async 'form.phone_number'() {
+      // form.phone_numberの値が変化したらだたちにfalseにする
+      // apiとの通信で、結果がNGでも一瞬だけtureになってしまうため
+      this.form.phoneNumberCheck = false
       const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
       if (format.test(this.form.phone_number)) {
         let msg
+
+        // apiへリクエスト
+        // 成功 case 'string'
+        // 失敗 case 'object'
         const res = await this.checkPhoneNumber()
         switch (typeof res) {
           case 'string':
             msg = res
+            this.form.phoneNumberCheck = true
             break
           case 'object':
             msg = res.response.data.message

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -30,12 +30,12 @@
               <v-text-field
                 id="name"
                 v-model="form.name"
-                :rules="[formValidates.required]"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
                 placeholder="田中 太郎"
                 outlined
                 dense
                 height="44"
+                :rules="[formValidates.required]"
             /></label>
           </div>
 


### PR DESCRIPTION
## やったこと

1. 電話番号ダブリチェックプログラムapiつなぎ合わせ

## やらないこと

- ケアマネの方(担当ではないので)
- 他のバリテーションはこのプルリクではやらない

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/phone-number-check-users-sign-up
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/users-phone-number-check
```

### 動作確認 Loom 手順

1. 存在する電話番号であればボタンが押せないことを確認する
- 存在する電話番号取得しとく
```ruby
Office.first.phone_number
User.first.phone_number
```
[loom動画](https://www.loom.com/share/2d5ccaddbbc64d8293857b34cc10e081)
### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [非同期なバリテーションルールを作成したい](https://stackoverflow.com/questions/49132167/how-to-validate-vuetify-text-field-asynchronously)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
