### PR TITLE
カスタマー側新規登録フォームバリテーション修正

### DIFF
--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -32,7 +32,7 @@
                 v-model="form.name"
                 :rules="[
                   formValidates.required,
-                  maxLength(form.name, '名前', 255),
+                  maxLength(form.name, '名前', 30),
                 ]"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
                 placeholder="田中 太郎"

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -30,7 +30,10 @@
               <v-text-field
                 id="name"
                 v-model="form.name"
-                :rules="[formValidates.required]"
+                :rules="[
+                  formValidates.required,
+                  maxLength(form.name, '名前', 255),
+                ]"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular"
                 placeholder="田中 太郎"
                 outlined
@@ -47,7 +50,11 @@
                 v-model="form.email"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
                 outlined
-                :rules="[formValidates.required, formValidates.email]"
+                :rules="[
+                  formValidates.required,
+                  maxLength(form.email, 'メールアドレス', 255),
+                  formValidates.email,
+                ]"
                 dense
                 placeholder="例) homecarenavi@mail.com"
                 type="email"
@@ -205,8 +212,8 @@ export default {
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字以下で入力してください',
         confirmCheck: (value) =>
           value === this.form.password || 'パスワードが一致しません',
         phoneNumber: (value) => {
@@ -266,6 +273,12 @@ export default {
   },
   methods: {
     ...mapActions('catchErrorMsg', ['clearMsg']),
+    // default: itemは255文字で以下で入力してください
+    maxLength(value, strItem = 'item', max = 255) {
+      return (
+        value.length <= max || `${strItem}は${max}文字以下で入力してください`
+      )
+    },
     async checkPhoneNumber() {
       const params = {
         phone_number: this.form.phone_number,

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -39,7 +39,6 @@
                 outlined
                 dense
                 height="44"
-                :rules="[formValidates.required]"
             /></label>
           </div>
 
@@ -60,7 +59,6 @@
                 placeholder="例) homecarenavi@mail.com"
                 type="email"
                 height="44"
-                :rules="[formValidates.required, formValidates.email]"
             /></label>
           </div>
 


### PR DESCRIPTION
## やったこと

- バリテーション修正 文字の長さ
name
email
password

## やらないこと

- ケアマネ側

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/validate-to-customer-sign-up
```

### 動作確認 Loom 手順

1. 新規登録フォームでバリテーションがかかるか確認する
name 30文字超えるとエラー
email 255文字超えるとエラー
password 8文字より小さいエラー
password 32文字超えるとエラー

開発者ツールのコンソールで〇〇文字文用意
```ruby
'a'.repeat(255)
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
