### PR TITLE
お礼の文字数のバリテーション修正

### DIFF
--- a/components/thank/new.vue
+++ b/components/thank/new.vue
@@ -119,7 +119,7 @@ export default {
         required: (value) => !!value || '必須項目です',
         objRequired: (value) => !!value.id || '必須項目です',
         strLength: (value) =>
-          value.length < 120 || '120文字以内で入力してください',
+          value.length <= 120 || '120文字以内で入力してください',
         nameLength: (value) =>
           value.length < 31 || '30文字以内で入力してください',
       },

--- a/pages/thanks/_id/edit.vue
+++ b/pages/thanks/_id/edit.vue
@@ -92,6 +92,9 @@ export default {
       rules.push(requiredRule)
       const updateRule = () => this.notMatch || '更新してください'
       rules.push(updateRule)
+      const maxLength = () =>
+        this.comment.length <= 120 || 'お礼は120文字以下で入力してください'
+      rules.push(maxLength)
       return rules
     },
   },


### PR DESCRIPTION
## やったこと

1. お礼関係のバリテーション修正

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/validate-to-thanks-new
```

### 動作確認 Loom 手順

1. オフィスページに詳細アクセス(ログイン済み)
2. お礼投稿ページのお礼の内容のとこで、120文字を超えるとエラー出るか確認する
[![Image from Gyazo](https://i.gyazo.com/60aed6474f7bf464c132acf7206ecf13.png)](https://gyazo.com/60aed6474f7bf464c132acf7206ecf13)
3. お礼履歴に遷移
[![Image from Gyazo](https://i.gyazo.com/890e1d53130e1e3d2fe62dfb0b6fa2c9.png)](https://gyazo.com/890e1d53130e1e3d2fe62dfb0b6fa2c9)
4. お礼の編集ページにて、120文字を超えるとエラーが出るか確認する


- 検証ツール 指定した文字数生成
```js
'a'.repeat(120)
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
