### PR TITLE
カスタマーでログイン時のみ閲覧データの登録・更新リクエスト

### DIFF
--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -31,7 +31,8 @@
 <script>
 export default {
   layout: 'application',
-  async asyncData({ $axios, params }) {
+  async asyncData({ $axios, params, store }) {
+    const flag = store.getters.getCustomerFlag
     const id = params.id
     try {
       const res = await $axios.$get(`offices/${id}`)
@@ -41,15 +42,18 @@ export default {
         staffs: res.staffs,
         bookmark: res.bookmark,
         history: res.history,
+        customerFlag: flag,
       }
     } catch (error) {
       return error
     }
   },
   mounted() {
-    this.history === null
-      ? this.submitHistory(this.office.id)
-      : this.updateHistory(this.office.id, this.history.id)
+    if (this.customerFlag === true) {
+      this.history === null
+        ? this.submitHistory(this.office.id)
+        : this.updateHistory(this.office.id, this.history.id)
+    }
   },
   methods: {
     async submitBookmark(officeId) {

--- a/pages/offices/_id/index.vue
+++ b/pages/offices/_id/index.vue
@@ -42,14 +42,14 @@ export default {
         staffs: res.staffs,
         bookmark: res.bookmark,
         history: res.history,
-        customerFlag: flag,
+        isLoggedInCustomer: flag,
       }
     } catch (error) {
       return error
     }
   },
   mounted() {
-    if (this.customerFlag === true) {
+    if (this.isLoggedInCustomer === true) {
       this.history === null
         ? this.submitHistory(this.office.id)
         : this.updateHistory(this.office.id, this.history.id)

--- a/store/index.js
+++ b/store/index.js
@@ -17,6 +17,10 @@ function setDefaultState() {
   }
 }
 
+export const getters = {
+  getCustomerFlag: (state) => state.customer,
+}
+
 export const mutations = {
   loginSpecialist(state) {
     state.specialist = true


### PR DESCRIPTION
## やったこと

- 事業所詳細画面にアクセスしたときに、未ログインでも閲覧データの登録・更新リクエストを送ってしまう不具合修正（「**ログインしてください**」というフラッシュメッセージが出ていた）
  - customerがログインしてるかどうかの状態が保存されているstoreの値を参照し、カスタマーでログインしているときだけリクエストを送信するように設定
## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/loggedin-only-request-history-submit-update
```

### 動作確認 Loom 手順

1. ログインする
2. 事業所詳細画面にアクセスする
3. 閲覧履歴に反映されているか確認
4. 未ログインで2を実施
5. エラーのフラッシュメッセージが出ていないか確認する

## 参考になったサイト

- [asyncData で mapGetters を実行するには?](https://stackoverflow.com/questions/58486000/how-to-do-mapgetters-in-asyncdata-nuxt)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
