### PR TITLE
カスタマー側 フラッシュメッセージ 色のバグ修正 200→緑 異常系→赤

### DIFF
--- a/components/ErrorMsg.vue
+++ b/components/ErrorMsg.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="my-2">
     <v-alert
-      v-for="(msg, i) in msgs"
+      v-for="(msg, i) in getMsg"
       :key="i"
-      :type="type"
+      :type="getType"
       max-width="750"
       min-width="350"
       dismissible
@@ -27,10 +27,10 @@ export default {
   },
   watch: {
     getMsg() {
-      this.msgs = this.getMsg
+      return this.getMsg
     },
     getType() {
-      this.type = this.getType
+      return this.getType
     },
   },
 }

--- a/components/ErrorMsg.vue
+++ b/components/ErrorMsg.vue
@@ -1,13 +1,14 @@
 <template>
   <div class="my-2">
     <v-alert
-      v-for="(msg, i) in getMsg"
+      v-for="(msg, i) in GetMsg"
       :key="i"
-      :type="getType"
+      :type="GetType"
       max-width="750"
       min-width="350"
       dismissible
       class="mx-auto mb-2"
+      :value="alert"
     >
       {{ msg }}
     </v-alert>
@@ -18,19 +19,31 @@ import { mapGetters } from 'vuex'
 export default {
   data() {
     return {
-      msgs: [],
-      type: 'error',
+      // v-alertコンポネント表示するかしないかのフラグ
+      // vale props 参照
+      // https://vuetifyjs.com/ja/api/v-alert/
+      alert: false,
     }
   },
   computed: {
-    ...mapGetters('catchErrorMsg', ['getMsg', 'getType', 'emptyState']),
-  },
-  watch: {
-    getMsg() {
+    ...mapGetters('catchErrorMsg', ['getMsg', 'getType']),
+    GetMsg() {
       return this.getMsg
     },
-    getType() {
+    GetType() {
       return this.getType
+    },
+  },
+  watch: {
+    // リクエストが成功: 指定した時間後にフラッシュ消える
+    // リクエストが失敗: 残り続ける ※エラー内容を読んでもらうたため
+    GetMsg() {
+      this.alert = true
+      if (this.GetType === 'success') {
+        setTimeout(() => {
+          this.alert = false
+        }, 5000)
+      }
     },
   },
 }

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -262,7 +262,7 @@
       <v-container fluid class="pa-0">
         <!-- vue-routerを使用する場合 -->
         <!--<router-view></router-view>-->
-        <ErrorMsg />
+        <ErrorMsg class="flash-msg-component" />
         <Nuxt />
       </v-container>
     </v-main>
@@ -403,6 +403,18 @@ export default {
 }
 </script>
 <style scoped>
+/* stylelint-disable */
+.flash-msg-component {
+  position: absolute;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  z-index: 999;
+}
+/* stylelint-enable */
+
 .text-10 {
   font-size: 10px;
 }

--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -259,7 +259,7 @@
     <!-- アプリケーションのコンポーネントに基づいてコンテンツのサイズを決定 -->
     <v-main class="color-gray">
       <!-- アプリケーションに適切なgutterを提供 -->
-      <v-container fluid class="pa-0">
+      <v-container fluid class="pa-0 pt-10">
         <!-- vue-routerを使用する場合 -->
         <!--<router-view></router-view>-->
         <ErrorMsg class="flash-msg-component" />

--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -50,7 +50,7 @@
 import { mapActions } from 'vuex'
 export default {
   layout: 'application',
-  async asyncData({ $axios, query, redirect }) {
+  async asyncData({ $axios, query }) {
     // console.log(query)
     // ここにkeywordの内容も追記すればリロードも対応できる
     const area = query.area || ''

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-990 mx-auto mt-n2 mb-2">
+  <div class="w-990 mx-auto mb-2">
     <SubTitle
       v-model="searchIcon.keyword"
       @clickKeywordsAndPostCodes="searchOfficeKeywordsAndPostCodes()"

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-990 mx-auto mb-2">
+  <div class="w-990 mx-auto mb-2 mt-n10">
     <SubTitle
       v-model="searchIcon.keyword"
       @clickKeywordsAndPostCodes="searchOfficeKeywordsAndPostCodes()"

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -3,6 +3,7 @@ const networkError = function (store, error) {
     store.commit('catchErrorMsg/clearMsg')
     const msg = ['送信ができませんでした。しばらく経ってから再度お願いします。']
     store.commit('catchErrorMsg/setMsg', msg)
+    store.commit('catchErrorMsg/setType', 'error')
   }
 }
 
@@ -34,18 +35,21 @@ const error422 = function (store, error) {
   const msg = error.response.data.errors.full_messages
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
+  store.commit('catchErrorMsg/setType', 'error')
 }
 
 const error401 = function (store, error) {
   const msg = error.response.data.errors
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
+  store.commit('catchErrorMsg/setType', 'error')
 }
 
 const error500 = function (store) {
   const msg = ['サーバー側のエラーです。しばらく経ってから再度お願いします。']
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
+  store.commit('catchErrorMsg/setType', 'error')
 }
 
 const setOfficeDate = function (officeData) {

--- a/store/catchErrorMsg.js
+++ b/store/catchErrorMsg.js
@@ -1,6 +1,6 @@
 export const state = () => ({
   msg: [],
-  type: [],
+  type: '',
 })
 export const getters = {
   getMsg: (state) => state.msg,


### PR DESCRIPTION
## やったこと

1. 色のバグ修正
2. トランジション
3. 時間で消える
4. レイアウトに影響を与えないように修正

## やらないこと

- バグの修正のみで、既存の機能によっては正しく設定しないないと色が白になったりする

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/flash-msg-color
```

### 動作確認 Loom 手順

1. ログイン・ログアウトを連続で実施して想定通りの色になっているか

※ okそうなら、ケアマネも同じように実装する

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

[position: absoluteにした要素を中央に寄せる](https://arts-factory.net/position/)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
