### PR TITLE
ケアマネ新規登録画面　電話番号バリデーション設定

### DIFF
--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card width="750" class="mx-auto mb-2 mt-2">
+  <v-card flat width="750" class="mx-auto mb-2 mt-2">
     <div class="px-4 pt-4 d-none d-sm-block">
       <p class="mb-0 text-right">
         <NuxtLink
@@ -101,6 +101,7 @@
                 v-model="form.phone_number"
                 outlined
                 dense
+                :error-messages="errors"
                 placeholder="080-1234-5678"
                 class="overwrite-fieldset-border-top-width mt-2 font-weight-regular set-max-width-520"
                 type="tel"
@@ -146,7 +147,7 @@
               id="send"
               class="warning pa-0 text-h6 d-none d-sm-block"
               block
-              :disabled="!form.valid"
+              :disabled="isValid"
               max-width="520"
               min-width="343"
               height="60"
@@ -157,7 +158,7 @@
               id="send"
               class="warning pa-0 ma-0 text-h6 d-block d-sm-none"
               block
-              :disabled="!form.valid"
+              :disabled="isValid"
               max-width="520"
               min-width="343"
               height="48"
@@ -185,7 +186,9 @@ export default {
         post_code: '',
         address: '',
         valid: false,
+        phoneNumberCheck: false,
       },
+      errors: [],
       formValidates: {
         required: (value) => !!value || '必須項目です',
         typeCheckString: (value) => {
@@ -216,8 +219,61 @@ export default {
       },
     }
   },
+  computed: {
+    // 新規登録ボタン押せる状態   false
+    // 新規登録ボタン押せない状態 true
+    isValid() {
+      // formのバリテーションルールをすべて突破している && 電話番号に被りがない
+      const flag = this.form.valid && this.form.phoneNumberCheck
+
+      // flag = false 新規登録ボタン押せる状態
+      // flag = true  新規登録ボタン押せない状態
+      return !flag
+    },
+  },
+  watch: {
+    // form.phene_numberの値がusersテーブルとofficesテーブルの被りがないかチェック
+    // 被りがあったら、'登録済みの電話番号です。'を表示 エラーメッセージはapiのレスポンスを使用している
+    async 'form.phone_number'() {
+      // form.phone_numberの値が変化したらだたちにfalseにする
+      // apiとの通信で、結果がNGでも一瞬だけtrueになってしまうため
+      this.form.phoneNumberCheck = false
+      const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
+      if (format.test(this.form.phone_number)) {
+        let msg
+
+        // apiへリクエスト
+        // 200 case 'string'
+        // 403 case 'object'
+        const res = await this.checkPhoneNumber()
+        switch (typeof res) {
+          case 'string':
+            msg = res
+            this.form.phoneNumberCheck = true
+            break
+          case 'object':
+            msg = res.response.data.message
+            this.errors.push(msg)
+            break
+        }
+      } else {
+        this.errors.pop()
+      }
+    },
+  },
   methods: {
     ...mapActions('catchErrorMsg', ['clearMsg']),
+    async checkPhoneNumber() {
+      const params = {
+        phone_number: this.form.phone_number,
+      }
+      try {
+        const res = await this.$axios.$get('check-phone-number', { params })
+        return res.message
+      } catch (error) {
+        return error
+      }
+    },
     async sign_up() {
       try {
         const response = await this.$axios.$post(`specialists/users`, {


### PR DESCRIPTION
## やったこと

- 電話番号バリデーション設定
事業所とユーザーで重複している場合は登録できなくなっています

## やらないこと

- その他のバリデーション（パスワードやメールアドレスのバリデーションはまだ漏れがあります）

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/specialist_registration
```

### 動作確認 Loom 手順


1. 存在する電話番号であればボタンが押せないことを確認する
- 存在する電話番号取得しとく
```ruby
Office.first.phone_number
User.first.phone_number
```


[確認動画](https://www.loom.com/share/bc125419e48549a8b11709bbf90a057f)
### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- #251 

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
