### PR TITLE
予約履歴画面　予約した回数分だけカードの表示

### DIFF
--- a/components/appointment/officeCard.vue
+++ b/components/appointment/officeCard.vue
@@ -1,0 +1,91 @@
+<template>
+  <v-col>
+    <v-card class="mx-auto">
+      <v-col
+        ><h3>{{ getOffice.name }}</h3></v-col
+      >
+      <v-row>
+        <v-avatar tile width="120" height="90" class="ml-6 mt-4 mb-8">
+          <v-img :src="displayImg"></v-img>
+        </v-avatar>
+        <v-col cols="6" class="pl-5 pr-0 access-and-staff">
+          <v-row class="mt-1">
+            <v-icon small>mdi-map-marker</v-icon>
+            <div class="my-auto pl-1">東京駅 徒歩5分</div>
+          </v-row>
+          <v-row class="pt-1">
+            <v-icon small>mdi-account</v-icon>
+            <div class="my-auto pl-1">
+              スタッフ数 {{ getOffice.staff_count }}人
+            </div>
+          </v-row>
+          <v-row class="pt-1">
+            <v-icon small>mdi-phone</v-icon>
+            <div class="my-auto pl-1">{{ getOffice.phone_number }}</div>
+          </v-row>
+        </v-col>
+      </v-row>
+      <v-divider class="mx-3"></v-divider>
+      <v-col class="mt-2 font-color-gray text-caption"
+        >予約した日時：{{ getAppointment.created_at | created_at }}</v-col
+      >
+      <v-col class="pb-0 font-color-gray font-weight-black text-caption"
+        >面談希望日時</v-col
+      >
+      <v-col class="py-0"
+        >{{ getAppointment.meet_date | meet_date }}
+        {{ getAppointment.meet_time }}</v-col
+      >
+      <v-col class="text-center pt-4 pb-6 font-color-gray">
+        <div v-if="getAppointment.called_status === 'need_call'">
+          事業所からの連絡をお待ち下さい
+        </div>
+        <div v-else-if="getAppointment.called_status === 'called'">
+          連絡済み
+        </div>
+        <div v-else>キャンセル済み</div>
+      </v-col>
+    </v-card>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    appointment: {
+      type: Object,
+      default() {
+        return null
+      },
+    },
+    office: {
+      type: Object,
+      default() {
+        return null
+      },
+    },
+  },
+  computed: {
+    getAppointment() {
+      return this.appointment
+    },
+    getOffice() {
+      return this.office
+    },
+    displayImg() {
+      return this.getOffice.first_image_url !== null
+        ? this.getOffice.first_image_url
+        : require('~/assets/images/no-image.png')
+    },
+  },
+}
+</script>
+<style scoped>
+.font-color-gray {
+  color: #6d7570;
+}
+
+.access-and-staff {
+  font-size: 12px;
+}
+</style>

--- a/pages/appointments/index.vue
+++ b/pages/appointments/index.vue
@@ -3,72 +3,19 @@
     <h3 class="pb-3">予約履歴</h3>
     <v-row>
       <v-col
-        v-for="(office, index) in getAPI"
+        v-for="(appointment, index) in appointments"
         :key="index"
         cols="12"
         md="6"
         class="px-0 pb-0 pt-0"
-        @click="moveShow(office.id)"
+        @click="moveShow(appointment.office)"
       >
-        <v-col>
-          <v-card class="mx-auto">
-            <v-col
-              ><h3>{{ office.name }}</h3></v-col
-            >
-            <v-row>
-              <v-avatar tile width="120" height="90" class="ml-6 mt-4 mb-8">
-                <v-img
-                  v-if="office.image.length !== 0"
-                  :src="office.image"
-                ></v-img>
-                <v-img
-                  v-else
-                  src="https://home-care-navi-bucket.s3.ap-northeast-1.amazonaws.com/no_image.jpeg"
-                ></v-img>
-              </v-avatar>
-              <v-col cols="6" class="pl-5 pr-0 access-and-staff">
-                <v-row class="mt-1">
-                  <v-icon small>mdi-map-marker</v-icon>
-                  <div class="my-auto pl-1">東京駅 徒歩5分</div>
-                </v-row>
-                <v-row class="pt-1">
-                  <v-icon small>mdi-account</v-icon>
-                  <div class="my-auto pl-1">
-                    スタッフ数 {{ office.staffCount }}人
-                  </div>
-                </v-row>
-                <v-row class="pt-1">
-                  <v-icon small>mdi-phone</v-icon>
-                  <div class="my-auto pl-1">{{ office.phone_number }}</div>
-                </v-row>
-              </v-col>
-            </v-row>
-            <v-divider class="mx-3"></v-divider>
-            <v-col class="mt-2 font-color-gray text-caption"
-              >予約した日時：{{
-                office.appointment.created_at | created_at
-              }}</v-col
-            >
-            <v-col class="pb-0 font-color-gray font-weight-black text-caption"
-              >面談希望日時</v-col
-            >
-            <v-col class="py-0"
-              >{{ office.appointment.meet_date | meet_date }}
-              {{ office.appointment.meet_time }}</v-col
-            >
-            <v-col class="text-center pt-4 pb-6 font-color-gray">
-              <div v-if="office.appointment.called_status === 'need_call'">
-                事業所からの連絡をお待ち下さい
-              </div>
-              <div v-else-if="office.appointment.called_status === 'called'">
-                連絡済み
-              </div>
-              <div v-else>キャンセル済み</div>
-            </v-col>
-          </v-card>
-        </v-col>
+        <AppointmentOfficeCard
+          :appointment="appointment"
+          :office="appointment.office"
+        />
       </v-col>
-      <v-col v-if="getAPI.length === 0">予約履歴はありません</v-col>
+      <v-col v-if="appointments.length === 0">予約履歴はありません</v-col>
     </v-row>
   </v-col>
 </template>
@@ -81,25 +28,16 @@ export default {
     try {
       const res = await $axios.$get(`appointments`)
       return {
-        getAPI: res,
+        appointments: res.appointment,
       }
     } catch (error) {
       return error
     }
   },
   methods: {
-    moveShow(id) {
-      this.$router.push({ path: `/offices/${id}` })
+    moveShow(office) {
+      this.$router.push({ path: `/offices/${office.id}` })
     },
   },
 }
 </script>
-<style scoped>
-.font-color-gray {
-  color: #6d7570;
-}
-
-.access-and-staff {
-  font-size: 12px;
-}
-</style>


### PR DESCRIPTION
## やったこと

- カスタマー側の予約履歴画面の構造を変更
  - 予約した回数分だけオフィスのカードを表示

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/fix-appointments-index
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/fix-customer-appointments-index-page
```

### 動作確認 Loom 手順

- 同じオフィスに2回予約する（ケアマネが持ってるオフィスに予約すること）
- ケアマネ側で2人の予約をキャンセル・連絡済みにする
- カスタマー側で両方反映されていれば 👍 

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
