### PR TITLE
フラッシュメッセージレイアウト組み込み ケアマネ

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -366,10 +366,10 @@
     <!-- アプリケーションのコンポーネントに基づいてコンテンツのサイズを決定 -->
     <v-main class="color-gray">
       <!-- アプリケーションに適切なgutterを提供 -->
-      <v-container fluid class="pa-0">
+      <v-container fluid class="pa-0 pt-10">
         <!-- vue-routerを使用する場合 -->
         <!--<router-view></router-view>-->
-        <ErrorMsg />
+        <ErrorMsg class="flash-msg-component" />
         <Nuxt />
       </v-container>
     </v-main>
@@ -503,6 +503,18 @@ export default {
 }
 </script>
 <style scoped>
+/* stylelint-disable */
+.flash-msg-component {
+  position: absolute;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  z-index: 999;
+}
+/* stylelint-enable */
+
 .text-10 {
   font-size: 10px;
 }


### PR DESCRIPTION
## やったこと

1. ケアマネのレイアウトにフラッシュメッセージ組み込み

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/flash-msg-color-for-sp
```

### 動作確認 Loom 手順

- ケアマネ画面の方で、ログイン・ログアウトを交互に行って想定通りの動作になっているか?
- こちらのプルリクのケアマネver
https://github.com/koki-takishita/home-care-navi-front/pull/267

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
