### PR TITLE
fix: リロードしてもレイアウト崩れないように修正

### DIFF
--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -34,14 +34,19 @@
           </v-row>
           <p v-else class="ma-0">条件にマッチする事業所は存在しません</p>
         </v-container>
-        <div class="text-center">
+
+        <!-- <client-only></client-only>
+        リロードするとページネーション崩れるエラー対応のため
+        ハイドレーションとは？: https://zenn.dev/00_/articles/c5130802d384b8238e4c
+        原因と思われる記事: https://zenn.dev/motoishimotoi/articles/5a6642d8790eaa -->
+        <client-only>
           <v-pagination
             v-model="page"
-            :length="count"
             color="#D9DEDE"
+            :length="count"
             class="page-nation"
           ></v-pagination>
-        </div>
+        </client-only>
       </v-col>
     </v-row>
   </v-container>
@@ -130,8 +135,6 @@ export default {
       cities: [],
       selectedList: [],
       location: false,
-      page: 0,
-      count: 0,
       keywords: '',
       postCodes: '',
       searchWind: '',


### PR DESCRIPTION
## やったこと

- オフィス一覧ページ、リロードするとページネーション崩れるバグ修正

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/office-bug
```

### 動作確認 Loom 手順

1. nuxt server heroku localで起動
2. オフィス一覧ページへアクセス
3. ページネーションが崩れていなければok

- heroku local
```ruby
yarn build

heroku local
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [同じ現象が起こっている人の記事](https://zenn.dev/motoishimotoi/articles/5a6642d8790eaa)
- [client-onlyの公式](https://nuxtjs.org/ja/docs/features/nuxt-components#client-only-%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
