### PR TITLE
fix: スタッフが0だとお礼の投稿ボタン表示されない・直接url叩くと元のページにリダレクト

### DIFF
--- a/components/office/officeStaffCard.vue
+++ b/components/office/officeStaffCard.vue
@@ -3,11 +3,13 @@
     <v-card id="staff-card" outlined class="d-flex justify-space-between pa-4">
       <v-card-title class="pa-0 font-weight-black">スタッフ紹介</v-card-title>
       <ThankBackLink
+        v-if="ReadStaffs.length"
         class="my-auto"
         :object="ReadOffice"
         :text="linkText"
         @movePage="moveThankNewPage"
       />
+      <p v-else class="my-auto">スタッフはまだ登録されていません</p>
     </v-card>
     <template v-for="staff in ReadStaffs">
       <StaffIntroductionCard :key="staff.id" class="pa-4 pt-0" :staff="staff" />

--- a/components/thank/new.vue
+++ b/components/thank/new.vue
@@ -126,6 +126,11 @@ export default {
       valid: false,
     }
   },
+  fetch() {
+    if (this.ReadStaffs.length === 0) {
+      this.$nuxt.context.redirect(`/offices/${this.ReadOffice.id}`)
+    }
+  },
   computed: {
     ageList() {
       const array = new Array(61)


### PR DESCRIPTION
## やったこと

1. オフィス詳細ページ
- スタッフの数が0
[![Image from Gyazo](https://i.gyazo.com/8ac7d133d3aa752aae132b00c3ab79ee.png)](https://gyazo.com/8ac7d133d3aa752aae132b00c3ab79ee)
- スタッフの数が1以上
[![Image from Gyazo](https://i.gyazo.com/daf1f94b3c19513d74ece566e5559d3f.png)](https://gyazo.com/daf1f94b3c19513d74ece566e5559d3f)
- スタッフ0の状態でurl直接叩くと元の画面リダイレクト(遷移できない)
[loom動画](https://www.loom.com/share/57449e5651c64606b7160582d5b3878c)
## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/restriction-thank-page
```

### 動作確認 Loom 手順

1. スタッフが存在するオフィスの詳細ページアクセス
- スタッフ一覧が表示されている
[![Image from Gyazo](https://i.gyazo.com/daf1f94b3c19513d74ece566e5559d3f.png)](https://gyazo.com/daf1f94b3c19513d74ece566e5559d3f)
- お礼投稿ページにアクセスできる
- url直うちでもアクセスできる
```ruby
# 詳細ページのurlの後ろにペースト
thanks/new
```
2. スタッフが存在しないオフィスの詳細ページにアクセス
- スタッフ一覧が↓のように表示される
[![Image from Gyazo](https://i.gyazo.com/8ac7d133d3aa752aae132b00c3ab79ee.png)](https://gyazo.com/8ac7d133d3aa752aae132b00c3ab79ee)
- url直接叩いても遷移しない
```ruby
# 詳細ページのurlの後ろにペースト
thanks/new
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
