### PR TITLE
ケアマネ新規登録画面　バリデーション修正

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-# yarn test:e2e
+yarn test:e2e

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-yarn test:e2e
+# yarn test:e2e

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -195,10 +195,11 @@ export default {
       errors: [],
       formValidates: {
         required: (value) => !!value || '必須項目です',
-        typeCheckString: (value) => {
-          const format = /^[a-zA-Z0-9]+$/g
-          return format.test(value) || '入力できるのは半角英数字のみです'
-        },
+        nameMaxlength: (value) =>
+          value.length <= 30 || '名前は30文字以下で入力してください',
+        emailMaxlength: (value) =>
+          value.length <= 255 ||
+          'メールアドレスは255文字以下で入力してください',
         email: (value) => {
           const format =
             // eslint-disable-next-line no-control-regex
@@ -208,16 +209,15 @@ export default {
         password: (value) =>
           (value.length >= 8 && value.length <= 32) ||
           '8文字以上32文字以下で入力してください',
-        emailMaxlength: (value) =>
-          value.length <= 255 ||
-          'メールアドレスは255文字以下で入力してください',
-        nameMaxlength: (value) =>
-          value.length <= 30 || '名前は30文字以下で入力してください',
         confirmCheck: (value) =>
           value === this.form.password || 'パスワードが一致しません',
         phoneNumber: (value) => {
           const format = /^\d{2,4}-\d{2,4}-\d{4}$/g
           return format.test(value) || '正しい電話番号ではありません'
+        },
+        typeCheckString: (value) => {
+          const format = /^[a-zA-Z0-9]+$/g
+          return format.test(value) || '入力できるのは半角英数字のみです'
         },
         postCode: (value) => {
           const format = /^[0-9]{3}-[0-9]{4}$/g

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -35,7 +35,7 @@
                 outlined
                 dense
                 height="44"
-                :rules="[formValidates.required]"
+                :rules="[formValidates.required, formValidates.nameMaxlength]"
             /></label>
           </div>
 
@@ -51,7 +51,11 @@
                 placeholder="例) homecarenavi@mail.com"
                 type="email"
                 height="44"
-                :rules="[formValidates.required, formValidates.email]"
+                :rules="[
+                  formValidates.required,
+                  formValidates.email,
+                  formValidates.emailMaxlength,
+                ]"
             /></label>
           </div>
 
@@ -202,8 +206,13 @@ export default {
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字以下で入力してください',
+        emailMaxlength: (value) =>
+          value.length <= 255 ||
+          'メールアドレスは255文字以下で入力してください',
+        nameMaxlength: (value) =>
+          value.length <= 30 || '名前は30文字以下で入力してください',
         confirmCheck: (value) =>
           value === this.form.password || 'パスワードが一致しません',
         phoneNumber: (value) => {

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -53,8 +53,8 @@
                 height="44"
                 :rules="[
                   formValidates.required,
-                  formValidates.email,
                   formValidates.emailMaxlength,
+                  formValidates.email,
                 ]"
             /></label>
           </div>


### PR DESCRIPTION
## やったこと

- ケアマネ新規画面バリデーション修正
・名前：30文字以下
・パスワード：8文字以上32文字以下
・email：255文字以下


### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/specialist_registration
```

### 動作確認 Loom 手順

1. 新規登録フォームでバリテーションがかかるか確認する
name 30文字超えるとエラー
email 255文字超えるとエラー
password 8文字より小さいエラー
password 32文字超えるとエラー

開発者ツールのコンソールで〇〇文字文用意
```ruby
'a'.repeat(255)
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)


## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
