### PR TITLE
ケアマネ/カスタマー ログインフォームバリテーション修正

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -366,10 +366,10 @@
     <!-- アプリケーションのコンポーネントに基づいてコンテンツのサイズを決定 -->
     <v-main class="color-gray">
       <!-- アプリケーションに適切なgutterを提供 -->
-      <v-container fluid class="pa-0">
+      <v-container fluid class="pa-0 pt-10">
         <!-- vue-routerを使用する場合 -->
         <!--<router-view></router-view>-->
-        <ErrorMsg />
+        <ErrorMsg class="flash-msg-component" />
         <Nuxt />
       </v-container>
     </v-main>
@@ -503,6 +503,18 @@ export default {
 }
 </script>
 <style scoped>
+/* stylelint-disable */
+.flash-msg-component {
+  position: absolute;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  z-index: 999;
+}
+/* stylelint-enable */
+
 .text-10 {
   font-size: 10px;
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,6 +49,7 @@ export default {
     '~/plugins/officeSearch/selectedArea.js',
     '~/plugins/officeSearch/currentLocation.js',
     '~/plugins/officeSearch/conversionKeywords.js',
+    '~/plugins/validates.js',
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -37,7 +37,7 @@
               v-model="loginInfo.email"
               :rules="[
                 formValidates.required,
-                maxLength(loginInfo.email, 'メールーアドレス'),
+                maxLength(loginInfo.email, 'メールアドレス'),
                 formValidates.email,
               ]"
               outlined

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -35,7 +35,11 @@
             <v-text-field
               id="email"
               v-model="loginInfo.email"
-              :rules="[formValidates.required, formValidates.email]"
+              :rules="[
+                formValidates.required,
+                maxLength(loginInfo.email, 'メールーアドレス'),
+                formValidates.email,
+              ]"
               outlined
               dense
               height="44"
@@ -117,6 +121,7 @@
 </template>
 
 <script>
+import { maxLength } from '@/plugins/validates'
 export default {
   layout: 'application_specialists',
   data() {
@@ -137,8 +142,8 @@ export default {
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字以下で入力してください',
         typeCheckString: (value) => {
           const format = /^[a-zA-Z0-9]+$/g
           return format.test(value) || '入力できるのは半角英数字のみです'
@@ -147,6 +152,7 @@ export default {
     }
   },
   methods: {
+    maxLength,
     goResetPassword() {
       this.$router.push({
         path: '/reset-passwords',

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -37,7 +37,7 @@
               v-model="loginInfo.email"
               :rules="[
                 formValidates.required,
-                maxLength(loginInfo.email, 'メールーアドレス'),
+                maxLength(loginInfo.email, 'メールアドレス'),
                 formValidates.email,
               ]"
               outlined

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -35,7 +35,11 @@
             <v-text-field
               id="email"
               v-model="loginInfo.email"
-              :rules="[formValidates.required, formValidates.email]"
+              :rules="[
+                formValidates.required,
+                maxLength(loginInfo.email, 'メールーアドレス'),
+                formValidates.email,
+              ]"
               outlined
               dense
               height="44"
@@ -115,8 +119,8 @@
     </div>
   </v-card>
 </template>
-
 <script>
+import { maxLength } from '@/plugins/validates'
 export default {
   layout: 'application',
   data() {
@@ -137,8 +141,8 @@ export default {
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字以下で入力してください',
         typeCheckString: (value) => {
           const format = /^[a-zA-Z0-9]+$/g
           return format.test(value) || '入力できるのは半角英数字のみです'
@@ -152,6 +156,7 @@ export default {
     }
   },
   methods: {
+    maxLength,
     goResetPassword() {
       this.$router.push({
         path: '/reset-passwords',

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -183,6 +183,7 @@
 </template>
 <script>
 import { mapActions } from 'vuex'
+import { maxLength } from '@/plugins/validates'
 export default {
   layout: 'application',
   data() {
@@ -273,12 +274,7 @@ export default {
   },
   methods: {
     ...mapActions('catchErrorMsg', ['clearMsg']),
-    // default: itemは255文字で以下で入力してください
-    maxLength(value, strItem = 'item', max = 255) {
-      return (
-        value.length <= max || `${strItem}は${max}文字以下で入力してください`
-      )
-    },
+    maxLength,
     async checkPhoneNumber() {
       const params = {
         phone_number: this.form.phone_number,

--- a/plugins/validates.js
+++ b/plugins/validates.js
@@ -1,0 +1,14 @@
+// 文字の長さを検証する
+// value:   値を指定
+// strItem: 項目名を指定
+// max:     最大の文字数を指定
+//
+// maxLength('山田 太郎', '名前', 6)
+// => true
+// maxLength('山田 太郎', '名前', 5)
+// => 名前は5文字以下で入力してください
+const maxLength = function (value, strItem = 'item', max = 255) {
+  return value.length <= max || `${strItem}は${max}文字以下で入力してください`
+}
+
+export { maxLength }


### PR DESCRIPTION
## やったこと

1. ログインフォームバリテーション設定
2. バリテーション共通関数化

## やらないこと

- maxLength以外の共通関数化

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/login-validation
```

### 動作確認 Loom 手順

1. ケアマネログインフォーム、↓を検証
- email: 255文字以下
- password: 8文字以上32文字以下
2. カスタマーログインフォーム、↓を検証
- email: 255文字以下
- password: 8文字以上32文字以下

```ruby
'a'.repeat(255)

'a.'repeat(32)
```

### バリテーションルール重複箇所移行方法
- `plugins/validates.js`に移行したいルールを記述
```js

const maxLength = function () {
  .
  .
}
const hoge = function () {
 .
 .
}

export { maxLength, hoge }  // 作成した関数を追加
```
- バリテーション使いたい画面で読み込み `import { maxLength } from '@/plugins/validates'`
```html
<template>
  <v-text-field
    :rules="[
      maxLength(form.email, 'メールーアドレス', 255),
      hoge(**).
    ]"
  >
  </v-text-field>
</template>
<script>
import { maxLength, hoge } from '@/plugins/validates'  // 読見込み
export default {
  .
  .
  methods: {
    maxLength,  // 呼び出す
    hoge
  }
}
</script>
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
