### PR TITLE
fix: オフィス検索エリア選択されないbug修正

### DIFF
--- a/components/ChooseCityCard.vue
+++ b/components/ChooseCityCard.vue
@@ -123,6 +123,7 @@ export default {
       // TODO 複数対応
       choosePrefecture: '',
       chooseItems: [],
+      chooseArea: '',
     }
   },
   computed: {
@@ -151,6 +152,8 @@ export default {
     if (this.cities.length === 0) {
       this.prefectures = this.getCities
     }
+    this.chooseArea = this.getCurrentArea
+    this.choosePrefecture = this.getCurrentPrefecture
   },
   methods: {
     ...mapActions('areaData', [


### PR DESCRIPTION
## やったこと

1. エリアが選択されないバグの修正

- befoer
[loom動画 修正前](https://www.loom.com/share/dfe60d48afef4804b9edbfdef0858bc3)
- after
[loom動画 修正後](https://www.loom.com/share/6306b1cdd932451e9ab237151c3182e8)

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/office-left-menu
```

### 動作確認 Loom 手順

1. トップページからエリアを選択して検索する
2. 選択したエリアが一覧ページと一致する
3. トップページにもどって、1~2までを何度繰り返しても問題なければok  
※ 手順は↓と同じ
[loom動画 修正後](https://www.loom.com/share/6306b1cdd932451e9ab237151c3182e8)

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
