### PR TITLE
APIサーバーが起動していない時は、遷移しないように

### DIFF
--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -55,7 +55,7 @@
 import { mapActions } from 'vuex'
 export default {
   layout: 'application',
-  async asyncData({ $axios, query }) {
+  async asyncData({ $axios, query, redirect }) {
     // console.log(query)
     // ここにkeywordの内容も追記すればリロードも対応できる
     const area = query.area || ''
@@ -119,10 +119,15 @@ export default {
       }
     } catch (error) {
       // リロードして消えるようだったら有効化 console.log(error)
-      // console.log(error)
-      if (error.message) {
+      if (
+        error.message ===
+        "Cannot read properties of undefined (reading 'status')"
+      ) {
+        redirect('/')
+      } else if (error.message) {
         alert(error.message)
       }
+
       return error
     }
   },


### PR DESCRIPTION
## やったこと

- サーバーがdownしている時は遷移しないように設定

before
[![Image from Gyazo](https://i.gyazo.com/27f335eeaedbb2d02c5e4cf6729cc5ba.gif)](https://gyazo.com/27f335eeaedbb2d02c5e4cf6729cc5ba)
after
[![Image from Gyazo](https://i.gyazo.com/268c89cbd5e759ad2a2f6b4a4a3998fb.gif)](https://gyazo.com/268c89cbd5e759ad2a2f6b4a4a3998fb)

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/office-500-error-bug
```

### 動作確認 Loom 手順

1. api側のサーバーを停止する
2. トップページからリクエストする
3. 一覧ページへ遷移せずに、フラッシュメッセージが表示されることを確認する

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
