### PR TITLE
パスワードリセット画面文字数制限のバリテーション修正

### DIFF
--- a/components/resetPasswords/new.vue
+++ b/components/resetPasswords/new.vue
@@ -14,8 +14,8 @@
         height="44"
         :rules="[
           formValidates.required,
+          maxLength(Email, 'メールアドレス'),
           formValidates.email,
-          formValidates.emailLength,
         ]"
     /></label>
     <v-btn
@@ -38,6 +38,7 @@
   </v-form>
 </template>
 <script>
+import { maxLength } from '@/plugins/validates'
 export default {
   props: {
     value: {
@@ -67,9 +68,6 @@ export default {
             /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21-\x5A\x53-\x7F]|\\[\x01-\x09\x0B\x0C\x0E-\x7F])+)\])$/g
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
-        emailLength: (value) =>
-          value.length <= 255 ||
-          'メールアドレスは255文字以下で入力してください',
       },
       valid: false,
     }
@@ -111,6 +109,7 @@ export default {
     },
   },
   methods: {
+    maxLength,
     clickResetBtn() {
       this.$emit('clickResetBtn')
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,6 +49,7 @@ export default {
     '~/plugins/officeSearch/selectedArea.js',
     '~/plugins/officeSearch/currentLocation.js',
     '~/plugins/officeSearch/conversionKeywords.js',
+    '~/plugins/validates.js',
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/pages/specialists/login.vue
+++ b/pages/specialists/login.vue
@@ -35,7 +35,11 @@
             <v-text-field
               id="email"
               v-model="loginInfo.email"
-              :rules="[formValidates.required, formValidates.email]"
+              :rules="[
+                formValidates.required,
+                maxLength(loginInfo.email, 'メールアドレス'),
+                formValidates.email,
+              ]"
               outlined
               dense
               height="44"
@@ -117,6 +121,7 @@
 </template>
 
 <script>
+import { maxLength } from '@/plugins/validates'
 export default {
   layout: 'application_specialists',
   data() {
@@ -137,8 +142,8 @@ export default {
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字以下で入力してください',
         typeCheckString: (value) => {
           const format = /^[a-zA-Z0-9]+$/g
           return format.test(value) || '入力できるのは半角英数字のみです'
@@ -147,6 +152,7 @@ export default {
     }
   },
   methods: {
+    maxLength,
     goResetPassword() {
       this.$router.push({
         path: '/reset-passwords',

--- a/pages/users/login.vue
+++ b/pages/users/login.vue
@@ -35,7 +35,11 @@
             <v-text-field
               id="email"
               v-model="loginInfo.email"
-              :rules="[formValidates.required, formValidates.email]"
+              :rules="[
+                formValidates.required,
+                maxLength(loginInfo.email, 'メールアドレス'),
+                formValidates.email,
+              ]"
               outlined
               dense
               height="44"
@@ -115,8 +119,8 @@
     </div>
   </v-card>
 </template>
-
 <script>
+import { maxLength } from '@/plugins/validates'
 export default {
   layout: 'application',
   data() {
@@ -137,8 +141,8 @@ export default {
           return format.test(value) || '正しいメールアドレスを入力してください'
         },
         password: (value) =>
-          (value.length >= 8 && value.length <= 16) ||
-          '8文字以上16文字未満で入力してください',
+          (value.length >= 8 && value.length <= 32) ||
+          '8文字以上32文字以下で入力してください',
         typeCheckString: (value) => {
           const format = /^[a-zA-Z0-9]+$/g
           return format.test(value) || '入力できるのは半角英数字のみです'
@@ -152,6 +156,7 @@ export default {
     }
   },
   methods: {
+    maxLength,
     goResetPassword() {
       this.$router.push({
         path: '/reset-passwords',

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -183,6 +183,7 @@
 </template>
 <script>
 import { mapActions } from 'vuex'
+import { maxLength } from '@/plugins/validates'
 export default {
   layout: 'application',
   data() {
@@ -273,12 +274,7 @@ export default {
   },
   methods: {
     ...mapActions('catchErrorMsg', ['clearMsg']),
-    // default: itemは255文字で以下で入力してください
-    maxLength(value, strItem = 'item', max = 255) {
-      return (
-        value.length <= max || `${strItem}は${max}文字以下で入力してください`
-      )
-    },
+    maxLength,
     async checkPhoneNumber() {
       const params = {
         phone_number: this.form.phone_number,

--- a/plugins/validates.js
+++ b/plugins/validates.js
@@ -1,0 +1,14 @@
+// 文字の長さを検証する
+// value:   値を指定
+// strItem: 項目名を指定
+// max:     最大の文字数を指定
+//
+// maxLength('山田 太郎', '名前', 6)
+// => true
+// maxLength('山田 太郎', '名前', 5)
+// => 名前は5文字以下で入力してください
+const maxLength = function (value, strItem = 'item', max = 255) {
+  return value.length <= max || `${strItem}は${max}文字以下で入力してください`
+}
+
+export { maxLength }


### PR DESCRIPTION
## やったこと

- emailのフォーマット関係なく255文字超えるとエラー出るように修正

### 変更fileは↓だけ ほかはmerge分
- components/resetPasswords/new.vue

## before
- ### emailのフォーマットのバリテーションルールが優先されているため、255文字制限が評価されない
[![Image from Gyazo](https://i.gyazo.com/29f936c760323a3022e354572cdecf33.gif)](https://gyazo.com/29f936c760323a3022e354572cdecf33)
- ### emailのフォーマット突破するとようやくかかりだす
[![Image from Gyazo](https://i.gyazo.com/f6394e50ef31ff08ff6473784f1955db.gif)](https://gyazo.com/f6394e50ef31ff08ff6473784f1955db)
## after
- ### 文字数が255文字超えたらフォーマット関係なくエラーが出る
[![Image from Gyazo](https://i.gyazo.com/15961177dc3fb5e0c58df219edca4c3c.gif)](https://gyazo.com/15961177dc3fb5e0c58df219edca4c3c)

## やらないこと

- このプルリクでやらないことは何か？（**やらない場合は、いつやるのかを明記する**）

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/password-reset-validation
```

### 動作確認 Loom 手順

※ やったことのGIFのafterと同じか確認する
1. ケアマネパスワードリセット画面文字制限超えるとエラーでる
2.  カスタマパスワードリセット画面文字制限超えるとエラーでる

```js
'b'.repeat(256)
```

### 確認書類

**URL は該当のものに変えること**  
[画面図](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
