### PR TITLE
ステータスコードによってエラーメッセージ表示

### DIFF
--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -7,14 +7,19 @@ const networkError = function (store, error) {
   }
 }
 
-const authError422and401 = function (store, error) {
+const catchAPIError = function (store, error) {
   const code = error.response.status
-  if (code === 422) {
-    error422(store, error)
-  } else if (code === 401) {
-    error401(store, error)
-  } else if (code === 500) {
-    error500(store)
+  switch (code) {
+    case 401:
+    case 403:
+    case 422:
+      error401and403and422(store, error)
+      break
+    case 500:
+      error500(store)
+      break
+    default:
+      otherError(store)
   }
 }
 
@@ -31,14 +36,14 @@ const setAuthInfoToHeader = function (config, store) {
   }
 }
 
-const error422 = function (store, error) {
-  const msg = error.response.data.errors.full_messages
+const otherError = function (store) {
+  const msg = ['障害が発生しました。サイト運営者にお問い合わせください。']
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
   store.commit('catchErrorMsg/setType', 'error')
 }
 
-const error401 = function (store, error) {
+const error401and403and422 = function (store, error) {
   const msg = error.response.data.errors
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
@@ -86,7 +91,7 @@ export default function ({ $axios, store, query }) {
   // TODO onResponseError onRequestErrorで分けたい
   $axios.onResponseError((error) => {
     networkError(store, error)
-    authError422and401(store, error)
+    catchAPIError(store, error)
   })
 
   $axios.onResponse((response) => {


### PR DESCRIPTION
## やったこと

- ステータスコードによってエラーメッセージ表示
   - 401・403・422のステータスコードはAPIから返ってくるエラーメッセージを表示
     - 認証系エラーとバリデーションエラーが該当します
   - 500エラーはネットワークエラーとしてフロントで用意したエラーメッセージを表示（すでに用意済み）
   - 上記に該当しないステータスコードが返ってきたときは、新たにフロントでメッセージを用意し、フラッシュメッセージに反映
     - **障害が発生しました。サイト運営者にお問い合わせください。**

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/render_error_msg-customer_appointments_controller
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/switch-error-msg-for-api-status-code
```

### 動作確認 Loom 手順
- 予約作成画面に遷移する
  - 名前・お困りごとを空白文字（半角・全角スペース）で入力する
  - 確認画面に行き、予約ボタンを押す
  - エラーメッセージが表示される
- APIでステータスコードを変えてみる
  - `app/controllers/api/customer/appointments_controller.rb` の19行目の`status: ~~`を変更

 before
```ruby
render status: :unprocessable_entity, json: { errors: appointment.errors.full_messages }
```
after
```ruby
render status: 404, json: { errors: appointment.errors.full_messages }
```
![image](https://user-images.githubusercontent.com/34031637/185272043-2df264b8-a319-4ace-a111-3c4cf700ebe4.png)

## 参考になったサイト

- [MDN HTTP レスポンスステータスコード](https://developer.mozilla.org/ja/docs/Web/HTTP/Status)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
