### PR TITLE
予約一覧画面の画像表示部分の条件分岐修正

### DIFF
--- a/components/appointment/officeCard.vue
+++ b/components/appointment/officeCard.vue
@@ -73,7 +73,7 @@ export default {
       return this.office
     },
     displayImg() {
-      return this.getOffice.first_image_url !== null
+      return this.getOffice.first_image_url.length > 0
         ? this.getOffice.first_image_url
         : require('~/assets/images/no-image.png')
     },


### PR DESCRIPTION
## やったこと

- 予約一覧画面の画像表示部分の条件分岐修正
  - 画像がないときはnullが返ってきたものを、空の配列を返すようにしたため

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/refactoring-bookmark-controller
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/appointments-index-display-img
```

### 動作確認 Loom 手順

- 予約一覧画面に遷移し、画像の表示が問題なくできるか確認する
  - 画像なしオフィス、画像ありオフィス
- APIのプルリクこちら
https://github.com/koki-takishita/home-care-navi-api/pull/156

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
