### PR TITLE
ログインしなくても遷移できる画面の追加

### DIFF
--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,10 +1,16 @@
 export default async function ({ $auth, store, redirect, route }) {
+  const permissionPaths = [
+    '/specialists/login',
+    '/specialists/users/new',
+    '/specialists/users/send',
+    '/reset-passwords',
+    '/reset-passwords/edit',
+    '/specialists/privacy_policy',
+    '/specialists/terms',
+    '/specialists/contacts/new',
+  ]
   if (
-    route.path !== '/specialists/login' &&
-    route.path !== '/specialists/users/new' &&
-    route.path !== '/specialists/users/send' &&
-    route.path !== '/reset-passwords' &&
-    route.path !== '/reset-passwords/edit' &&
+    !permissionPaths.includes(route.path) &&
     store.state.specialist !== true
   ) {
     await $auth.logout()

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,6 +1,7 @@
 export default async function ({ $auth, store, redirect, route }) {
   const permissionPaths = [
     '/specialists/login',
+    '/specialists/login/',
     '/specialists/users/new',
     '/specialists/users/send',
     '/reset-passwords',

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -1,7 +1,6 @@
 export default async function ({ $auth, store, redirect, route }) {
   const permissionPaths = [
     '/specialists/login',
-    '/specialists/login/',
     '/specialists/users/new',
     '/specialists/users/send',
     '/reset-passwords',
@@ -16,7 +15,7 @@ export default async function ({ $auth, store, redirect, route }) {
     !permissionPaths.includes(route.path) &&
     store.state.specialist !== true
   ) {
-    await $auth.logout()
+    await $auth.reset()
     return redirect('/specialists/login')
   }
 }

--- a/middleware/authenticateSpecialist.js
+++ b/middleware/authenticateSpecialist.js
@@ -8,6 +8,8 @@ export default async function ({ $auth, store, redirect, route }) {
     '/specialists/privacy_policy',
     '/specialists/terms',
     '/specialists/contacts/new',
+    '/specialists/contacts/confirm',
+    '/specialists/contacts/success',
   ]
   if (
     !permissionPaths.includes(route.path) &&


### PR DESCRIPTION
## やったこと

- ケアマネがログインしなくてもフッターのリンクにアクセスできるよう修正
- ログイン画面でログアウト処理が走る不具合の修正



### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/specialist_login_to
```

### 動作確認 Loom 手順

### ケアマネがログインしなくてもフッターのリンクにアクセスできる
ログインしていない状態で下記にアクセスする

- プライバシーポリシー
`http://localhost:8000/specialists/privacy_policy`

- 利用規約
`http://localhost:8000/specialists/terms`

- 問い合わせ
`http://localhost:8000/specialists/terms`

### ログイン画面でログアウト処理が走る不具合
ケアマネとカスタマーのログイン画面を行き来してコンソールでエラーがないことを確認する


## 参考になったサイト

なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
