### PR TITLE
アップロードする画像の拡張子を制限

### DIFF
--- a/pages/specialists/office/care-recipients/_care_recipient_id/edit.vue
+++ b/pages/specialists/office/care-recipients/_care_recipient_id/edit.vue
@@ -22,7 +22,7 @@
             v-model="image"
             truncate-length="20"
             :rules="[formValidates.fileSizeCheck]"
-            accept="image/*"
+            accept="image/png, image/jpeg, image/jpg, image/gif"
             prepend-icon="mdi-camera"
             label="画像をアップロードする"
             class="mt-15 ml-3 image-form"

--- a/pages/specialists/office/care-recipients/new.vue
+++ b/pages/specialists/office/care-recipients/new.vue
@@ -18,7 +18,7 @@
             v-model="image"
             truncate-length="20"
             :rules="[formValidates.fileSizeCheck]"
-            accept="image/*"
+            accept="image/png, image/jpeg, image/jpg, image/gif"
             prepend-icon="mdi-camera"
             label="画像をアップロードする"
             class="mt-15 ml-3 image-form"

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -50,7 +50,7 @@
               formValidates.fileSizeCheck,
             ]"
             truncate-length="30"
-            accept="image/*"
+            accept="image/png, image/jpeg, image/jpg, image/gif"
             prepend-icon="mdi-camera"
             label="事業所画像をアップロード（5枚まで）"
             class="image-form"
@@ -269,7 +269,7 @@
                   <v-file-input
                     v-model="detail_image_1"
                     truncate-length="20"
-                    accept="image/*"
+                    accept="image/png, image/jpeg, image/jpg, image/gif"
                     show-size
                     label="特徴画像1をアップロード"
                     :rules="[formValidates.fileDetailSizeCheck]"
@@ -321,7 +321,7 @@
                   <v-file-input
                     v-model="detail_image_2"
                     truncate-length="20"
-                    accept="image/*"
+                    accept="image/png, image/jpeg, image/jpg, image/gif"
                     show-size
                     label="特徴画像2をアップロード"
                     :rules="[formValidates.fileDetailSizeCheck]"

--- a/pages/specialists/office/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/staffs/_staff_id/edit.vue
@@ -22,7 +22,7 @@
             v-model="image"
             truncate-length="20"
             :rules="[formValidates.fileSizeCheck]"
-            accept="image/*"
+            accept="image/png, image/jpeg, image/jpg, image/gif"
             prepend-icon="mdi-camera"
             label="画像をアップロードする"
             class="mt-15 ml-3 image-form"

--- a/pages/specialists/office/staffs/new.vue
+++ b/pages/specialists/office/staffs/new.vue
@@ -18,7 +18,7 @@
             v-model="image"
             truncate-length="20"
             :rules="[formValidates.fileSizeCheck]"
-            accept="image/*"
+            accept="image/png, image/jpeg, image/jpg, image/gif"
             prepend-icon="mdi-camera"
             label="画像をアップロードする"
             class="mt-15 ml-3 image-form"


### PR DESCRIPTION
## やったこと
- svgの画像を登録したときに、画像が表示されないバグ修正
  - 画像の拡張子が多すぎて管理しきれなく、今後もこういうバグが出てきそうなので、拡張子を制限しました。
    - アップロードする画像の拡張子を制限（PNG, JPEG, JPG, GIFのみ）

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/add-image-upload-permission-extension
```

### 動作確認 Loom 手順

- スタッフや利用者などを登録・編集するときに、指定された拡張子以外の画像が選択できないか確認
- svgサンプル画像
![samples-svgrepo-com](https://user-images.githubusercontent.com/34031637/185558907-6dc2e839-7c4c-4367-8c6c-3eac9040c31b.svg)

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
