### PR TITLE
オフィス検索異常系のバグ修正

### DIFF
--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -279,7 +279,7 @@ export default {
         })
       } catch (error) {
         const msg = [
-          '不明なエラーです。consoleを確認してください。 page/offices/index.vue 137',
+          '不明なエラーです。consoleを確認してください。 page/offices/index.vue',
         ]
         switch (error.name) {
           case 'Error': // officeが見つからない

--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -55,7 +55,7 @@
 import { mapActions } from 'vuex'
 export default {
   layout: 'application',
-  async asyncData({ $axios, query, redirect }) {
+  async asyncData({ $axios, query, redirect, store }) {
     // console.log(query)
     // ここにkeywordの内容も追記すればリロードも対応できる
     const area = query.area || ''
@@ -126,10 +126,24 @@ export default {
         searchIcon,
       }
     } catch (error) {
-      // リロードして消えるようだったら有効化 console.log(error)
-      if (error.message) {
-        alert(error.message)
-        redirect('/')
+      // console.dir(error)
+      const msg = [
+        '不明なエラーです。consoleを確認してください。 page/offices/index.vue 137',
+      ]
+      switch (error.name) {
+        case 'Error': // officeが見つからない
+          alert(error.message)
+          redirect('/')
+          break
+        case 'NetworkError': // 通信エラー
+          redirect('/')
+          break
+        default:
+          // console.dir(error)
+          store.commit('catchErrorMsg/clearMsg')
+          store.commit('catchErrorMsg/setMsg', msg)
+          store.commit('catchErrorMsg/setType', 'error')
+          redirect('/')
       }
 
       return error
@@ -244,8 +258,6 @@ export default {
         const offices = res.offices
         const keywords = res.keywords
         const postCodes = res.postCodes
-        if (!this.exist(offices))
-          return alert('検索ワードに一致するオフィスは、見つかりませんでした')
         this.offices = offices
         this.keywords = keywords
         this.postCodes = postCodes
@@ -266,12 +278,21 @@ export default {
           },
         })
       } catch (error) {
-        // console.log(error)
-        // console.dir(error)
-        if (error.message) {
-          alert(error.message)
+        const msg = [
+          '不明なエラーです。consoleを確認してください。 page/offices/index.vue 137',
+        ]
+        switch (error.name) {
+          case 'Error': // officeが見つからない
+            alert(error.message)
+            break
+          case 'NetworkError': // 通信エラー
+            break
+          default:
+            // console.dir(error)
+            store.commit('catchErrorMsg/clearMsg')
+            store.commit('catchErrorMsg/setMsg', msg)
+            store.commit('catchErrorMsg/setType', 'error')
         }
-        return error
       }
     },
     exist(obj) {

--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -128,7 +128,7 @@ export default {
     } catch (error) {
       // console.dir(error)
       const msg = [
-        '不明なエラーです。consoleを確認してください。 page/offices/index.vue 137',
+        '不明なエラーです。consoleを確認してください。 page/offices/index.vue',
       ]
       switch (error.name) {
         case 'Error': // officeが見つからない

--- a/pages/offices/index.vue
+++ b/pages/offices/index.vue
@@ -79,6 +79,9 @@ export default {
           `offices?prefecture=${prefecture}&cities=${cities}&page=${offsetPage}`
         )
         searchWind = false
+        if (offices.length === 0) {
+          throw new Error('選択したエリアにオフィスは存在しません')
+        }
       }
       if (!!postCodes.length > 0 || !!keywords.length > 0) {
         offices = await $axios.$get(
@@ -87,6 +90,11 @@ export default {
           )}&postCodes=${postCodes}&page=${offsetPage}`
         )
         searchWind = true
+        if (offices.length === 0) {
+          throw new Error(
+            '検索ワードに一致するオフィスは、見つかりませんでした'
+          )
+        }
       }
       let searchIcon = { keyword: '' }
       if (keywords.length > 0 && postCodes.length > 0) {
@@ -119,13 +127,9 @@ export default {
       }
     } catch (error) {
       // リロードして消えるようだったら有効化 console.log(error)
-      if (
-        error.message ===
-        "Cannot read properties of undefined (reading 'status')"
-      ) {
-        redirect('/')
-      } else if (error.message) {
+      if (error.message) {
         alert(error.message)
+        redirect('/')
       }
 
       return error

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -43,12 +43,6 @@ export default {
     async searchOfficeKeywordsAndPostCodes() {
       try {
         const res = await this.$conversionKeywords(this.searchIcon.keyword)
-        // officeのレスポンスが空だったら、アラートメッセージ表示
-        if (res.offices.length === 0) {
-          throw new Error(
-            '検索ワードに一致するオフィスは、見つかりませんでした'
-          )
-        }
         this.$router.push({
           path: '/offices',
           query: {
@@ -57,11 +51,21 @@ export default {
           },
         })
       } catch (error) {
-        // console.dir(error)
-        if (error.message) {
-          alert(error.message)
+        const msg = [
+          '不明なエラーです。consoleを確認してください。 page/offices/index.vue 137',
+        ]
+        switch (error.name) {
+          case 'Error': // officeが見つからない
+            alert(error.message)
+            break
+          case 'NetworkError': // 通信エラー
+            break
+          default:
+            // console.dir(error)
+            store.commit('catchErrorMsg/clearMsg')
+            store.commit('catchErrorMsg/setMsg', msg)
+            store.commit('catchErrorMsg/setType', 'error')
         }
-        return error
       }
     },
     async searchOfficeLocation() {

--- a/pages/top.vue
+++ b/pages/top.vue
@@ -52,7 +52,7 @@ export default {
         })
       } catch (error) {
         const msg = [
-          '不明なエラーです。consoleを確認してください。 page/offices/index.vue 137',
+          '不明なエラーです。consoleを確認してください。 page/offices/index.vue',
         ]
         switch (error.name) {
           case 'Error': // officeが見つからない

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -4,6 +4,9 @@ const networkError = function (store, error) {
     const msg = ['送信ができませんでした。しばらく経ってから再度お願いします。']
     store.commit('catchErrorMsg/setMsg', msg)
     store.commit('catchErrorMsg/setType', 'error')
+    const e = new Error('Apiと通信できませんでした')
+    e.name = 'NetworkError'
+    throw e
   }
 }
 

--- a/plugins/officeSearch/conversionKeywords.js
+++ b/plugins/officeSearch/conversionKeywords.js
@@ -123,15 +123,13 @@ const searchOfficeKeywords = async function (
   postCodes = null,
   axios
 ) {
-  try {
-    const offices = await axios.$get(
-      `offices?keywords=${keywords}&postCodes=${postCodes}&page=${0}`
-    )
-    return offices
-  } catch (error) {
-    // console.log(error)
-    return error
+  const offices = await axios.$get(
+    `offices?keywords=${keywords}&postCodes=${postCodes}&page=${0}`
+  )
+  if (offices.length === 0) {
+    throw new Error('検索ワードに一致するオフィスは、見つかりませんでした')
   }
+  return offices
 }
 
 export default function ({ $axios }, inject) {
@@ -157,7 +155,6 @@ export default function ({ $axios }, inject) {
       ["さんぷる", "113-5511", "2-11-39", "080-1111-1111", "014-4155", "さんぷる3"]
       => ['サンプル', 'サンプル3'] */
       const requestKeywords = removePostCode(keywordsArry)
-      // this.searchOfficeKeywords(requestKeywords, requestPostalCodes)
       const res = await searchOfficeKeywords(
         requestKeywords,
         requestPostalCodes,


### PR DESCRIPTION
## やったこと

- オフィス検索異常系の修正

## やらないこと

- このプルリクでやらないことは何か？（**やらない場合は、いつやるのかを明記する**）

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/office-area-bug
```

### 動作確認 Loom 手順

- 一覧ページ
  - 検索窓
    1. 空の状態で検索
    2. 空白の状態で検索
    3. 存在しない検索ワード(オフィス名、住所、郵便番号)
    4. 存在しない検索ワード(cの複数組み合わせ)
    5. apiサーバー落とした状態で検索
    [loom動画](https://www.loom.com/share/d57c2181615e425497fa7c5383496d4c)
  - エリア選択パネル
    1. city未選択の状態で検索
    2. 存在しない地域で検索
    3. apiサーバー落とした状態で検索
    [loom動画](https://www.loom.com/share/6ab8abad847847a8ac9f0071fcbd2b5d)

- トップページ
  - 検索窓
      一覧ページと同じ項目
     [loom動画](https://www.loom.com/share/a75cc46c51634c328ccae39b94cc3867)
  - エリア選択パネル
    一覧ページと同じ項目
    [loom動画](https://www.loom.com/share/926f5f1dc55243df972cbd01b4966f50)

- 現在地
  1. apiサーバー落とした状態
  2. 現在地のデータ(新潟県・佐渡市)のデータ消した状態でリクエスト
  [loom動画](https://www.loom.com/share/e0da9dc6395442dd8a4c55d1affbc9f6)

### 確認書類

[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
