### PR TITLE
スタッフいないとき利用者登録遷移できないよう設定

### DIFF
--- a/pages/specialists/office/care-recipients/index.vue
+++ b/pages/specialists/office/care-recipients/index.vue
@@ -90,7 +90,7 @@
       large
       color="white"
       class="mt-8 mb-10"
-      to="care-recipients/new"
+      @click="hasStaff"
     >
       <div class="delete-button font-weight-bold">
         <v-icon class="mb-1">mdi-plus</v-icon>
@@ -119,6 +119,9 @@ export default {
       const res = await $axios.$get(
         `specialists/offices/care_recipients?page=${offsetPage}`
       )
+      const staffs = await $axios.$get(`specialists/offices/staffs?page=1`)
+      const staffsCount = staffs.data_length
+
       let count = res.data_length
       count = count / 10 || 0
       count = Math.ceil(count)
@@ -126,6 +129,7 @@ export default {
         count = 1
       }
       return {
+        staffsCount,
         page,
         count,
         care_recipients: res.care_recipients,
@@ -153,6 +157,17 @@ export default {
     },
   },
   methods: {
+    hasStaff() {
+      this.staffsCount
+        ? this.goRegistrationPage()
+        : this.alertRegistrationStaff()
+    },
+    goRegistrationPage() {
+      this.$router.push('/specialists/office/care-recipients/new')
+    },
+    alertRegistrationStaff() {
+      alert('スタッフを登録してください')
+    },
     async getCareRecipients(page = 1) {
       try {
         const offsetPage = page - 1


### PR DESCRIPTION
## やったこと

- スタッフがいない時に利用者を追加できないように設定

## やらないこと

- URL直打ち対策はしてないです

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/care-recipient_to
```

### 動作確認 Loom 手順

- スタッフがいない状態で利用者を登録しようとする

```ruby
手順1.ケアマネでログイン
手順2.ログインしたケアマネのオフィスに紐ずくスタッフを全削除
手順3.利用者を登録しようとする
手順4.アラート出る
手順5.スタッフ作る
手順6.利用者追加できる
```
[確認動画](https://www.loom.com/share/1763ccf182a446929094a84535b83565)



## 参考になったサイト

- なし
## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
