### PR TITLE
お礼作成時のフラッシュメッセージ個別のメッセージが表示されるように修正

### DIFF
--- a/pages/offices/_id/thanks/new.vue
+++ b/pages/offices/_id/thanks/new.vue
@@ -125,9 +125,6 @@ export default {
           },
         })
       } catch (error) {
-        const msg = error.response.data.message
-        this.$store.commit('catchErrorMsg/setType', 'error')
-        this.$store.commit('catchErrorMsg/setMsg', [msg])
         return error
       }
     },


### PR DESCRIPTION
## やったこと

フラッシュメッセージの処理が２重にはしっており、今回消した処理で`plugin/axios.js`のフラッシュの内容が上書きされていた
使いたいのは`plugin/axios.js`内に記述されているフラッシュメッセージの処理だったので、`page/offices/_id/thanks/new.vue`こちらの内容は削除した
削除したところ、`plugin/axios.js`内に記述されている下記の処理で動作確認できた。
```js
const error401and403and422 = function (store, error) {
  let msg
  if (error.response.data.errors.full_messages === undefined) {
    msg = error.response.data.errors
  } else {
    msg = error.response.data.errors.full_messages
  }
  store.commit('catchErrorMsg/clearMsg')
  store.commit('catchErrorMsg/setMsg', msg)
  store.commit('catchErrorMsg/setType', 'error')
}

```

## やらないこと

- なし

### Api側
- 下記のプルリク参照
https://github.com/koki-takishita/home-care-navi-api/pull/168

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/f-thank-error-msg
```

### 動作確認 Loom 手順

1. お礼を作する
2. 同じスタッフでお礼を作成する
3. 画像のようなフラッシュメッセージがでていることを確認する
4. お礼投稿テスト確認して問題ないか

- loom動画
[同じスタッフに２回以上お礼を投稿するとエラーが出る](https://www.loom.com/share/11b6afaf8aaa43ec98694d88e1400f84)
- 画像
[![Image from Gyazo](https://i.gyazo.com/cdd63bb1b3ad3b77f58fdad4fe82d0e3.png)](https://gyazo.com/cdd63bb1b3ad3b77f58fdad4fe82d0e3)

### 確認書類

**URL は該当のものに変えること**  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [x] コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
