### PR TITLE
画像バリデーション バイトサイズ正しいものに変更

### DIFF
--- a/pages/specialists/office/care-recipients/_care_recipient_id/edit.vue
+++ b/pages/specialists/office/care-recipients/_care_recipient_id/edit.vue
@@ -186,7 +186,7 @@ export default {
         required: (value) => !!value || '必須項目です',
         fileSizeCheck: (value) =>
           !value ||
-          value.size <= 10000000 ||
+          value.size <= 10485760 ||
           '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
           value.length <= 30 || '30文字以下で入力してください',

--- a/pages/specialists/office/care-recipients/new.vue
+++ b/pages/specialists/office/care-recipients/new.vue
@@ -176,7 +176,7 @@ export default {
         required: (value) => !!value || '必須項目です',
         fileSizeCheck: (value) =>
           !value ||
-          value.size <= 10000000 ||
+          value.size <= 10485760 ||
           '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
           value.length <= 30 || '30文字以下で入力してください',

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -483,11 +483,11 @@ export default {
           value.length <= 200 || '200文字以下で入力してください',
         fileSizeCheck: (values) =>
           !values ||
-          !values.some((value) => value.size >= 10000000) ||
+          !values.some((value) => value.size > 10485760) ||
           '画像サイズは10MB以下でアップロードしてください',
         fileDetailSizeCheck: (value) =>
           !value ||
-          value.size <= 10000000 ||
+          value.size <= 10485760 ||
           '画像サイズは10MB以下でアップロードしてください',
         fileLengthCheck: (value) =>
           value.length <= 5 || '画像は5枚以下にしてください',

--- a/pages/specialists/office/staffs/_staff_id/edit.vue
+++ b/pages/specialists/office/staffs/_staff_id/edit.vue
@@ -117,7 +117,7 @@ export default {
         required: (value) => !!value || '必須項目です',
         fileSizeCheck: (value) =>
           !value ||
-          value.size <= 10000000 ||
+          value.size <= 10485760 ||
           '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
           value.length <= 30 || '30文字以下で入力してください',

--- a/pages/specialists/office/staffs/new.vue
+++ b/pages/specialists/office/staffs/new.vue
@@ -104,7 +104,7 @@ export default {
         required: (value) => !!value || '必須項目です',
         fileSizeCheck: (value) =>
           !value ||
-          value.size <= 10000000 ||
+          value.size <= 10485760 ||
           '画像サイズは10MB以下でアップロードしてください',
         nameCountCheck: (value) =>
           value.length <= 30 || '30文字以下で入力してください',


### PR DESCRIPTION
## やったこと

- 10MBを超える画像を登録させないバリデーションを設定していたが、10MBピッタリの画像がアップロードできなかったので、正しいものに設定
  - 10MBをバイトに変換すると`10,485,760`であるため、バイト数が`10,485,761`以上のものをアップロードするとバリデーションがかかるように修正

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/image-validation
```

### 動作確認 Loom 手順

- 事業所、スタッフ、利用者で画像アップロードを試す
- 10MBピッタリの画像はアップロードできる
![sample_10mb_image](https://user-images.githubusercontent.com/34031637/186567215-397bbca1-a71c-4e22-9df6-fe3d2168a09b.png)

- 10MBを超えるものはアップロードできない

[こちらのサイトのsample_5184×3456.pngをダウンロードしてください（34.24MB）](https://filesamples.com/formats/png)

### 確認書類
 
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [バイト換算表](https://pasomaki.com/pc-byte-conversion/)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
