### PR TITLE
ケアマネ側、ログイン後のアイコンクリック時の遷移先設定

### DIFF
--- a/layouts/application_specialists.vue
+++ b/layouts/application_specialists.vue
@@ -448,8 +448,8 @@
     </v-footer>
   </v-app>
 </template>
-
 <script>
+import { mapGetters } from 'vuex'
 export default {
   layout: 'top',
   middleware: 'authenticateSpecialist',
@@ -471,6 +471,9 @@ export default {
       office_id: '',
     }
   },
+  computed: {
+    ...mapGetters(['getOffice']),
+  },
   watch: {
     $route() {
       if (typeof window.localStorage.office_data !== 'undefined') {
@@ -487,10 +490,15 @@ export default {
       this.office = false
     }
   },
-
   methods: {
     topPage() {
+      if (!this.getOffice) {
+        return this.goOfficeNewPage()
+      }
       this.$auth.loggedIn ? this.goAppointmentsPage() : this.goLoginPage()
+    },
+    goOfficeNewPage() {
+      this.$router.push('/specialists/office/new')
     },
     goLoginPage() {
       this.$router.push('/specialists/login')

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -254,16 +254,21 @@ export default {
         // apiへリクエスト
         // 200 case 'string'
         // 403 case 'object'
-        const res = await this.checkPhoneNumber()
-        switch (typeof res) {
-          case 'string':
-            msg = res
-            this.form.phoneNumberCheck = true
-            break
-          case 'object':
-            msg = res.response.data.message
-            this.errors.push(msg)
-            break
+        try {
+          const res = await this.checkPhoneNumber()
+          switch (typeof res) {
+            case 'string':
+              msg = res
+              this.form.phoneNumberCheck = true
+              break
+            case 'object':
+              msg = res.response.data.message
+              this.errors.push(msg)
+              break
+          }
+        } catch (error) {
+          // console.dir(error)
+          return error
         }
       } else {
         this.errors.pop()

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -256,16 +256,21 @@ export default {
         // apiへリクエスト
         // 200 case 'string'
         // 403 case 'object'
-        const res = await this.checkPhoneNumber()
-        switch (typeof res) {
-          case 'string':
-            msg = res
-            this.form.phoneNumberCheck = true
-            break
-          case 'object':
-            msg = res.response.data.message
-            this.errors.push(msg)
-            break
+        try {
+          const res = await this.checkPhoneNumber()
+          switch (typeof res) {
+            case 'string':
+              msg = res
+              this.form.phoneNumberCheck = true
+              break
+            case 'object':
+              msg = res.response.data.message
+              this.errors.push(msg)
+              break
+          }
+        } catch (error) {
+          // console.dir(error)
+          return error
         }
       } else {
         this.errors.pop()

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -16,14 +16,28 @@ const catchAPIError = function (store, error) {
     case 401:
     case 403:
     case 422:
+      if (skipErrorCatch(error, ['check-phone-number'])) {
+        return
+      }
       error401and403and422(store, error)
       break
+    /* case 404: TODO パスワードリセット404の対応
+      if (skipErrorCatch(error, ['reset-passwords'])) {
+        return
+      }
+      // console.dir(response)
+      break */
     case 500:
       error500(store)
       break
     default:
       otherError(store)
   }
+}
+
+const skipErrorCatch = function (error, skipEndPoints) {
+  const url = error.response.config.url
+  return skipEndPoints.includes(url)
 }
 
 const setAuthInfoToHeader = function (config, store) {

--- a/store/index.js
+++ b/store/index.js
@@ -20,6 +20,7 @@ function setDefaultState() {
 
 export const getters = {
   getCustomerFlag: (state) => state.customer,
+  getOffice: (state) => state.office,
 }
 
 export const mutations = {


### PR DESCRIPTION
## やったこと

- オフィスがないケアマネ、左上アイコンクリックするとホワイト・アウトするバグ修正

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/move-top-page-to-specialist
```

### 動作確認 Loom 手順

- ケアマネのデータ用意する
  - officeを持ってないユーザ
  - office持っているユーザ

1. ケアマネログインする(office持ってない)
2. ログイン成功後、アイコンクリックするとofficeの新規作成画面ヘ遷移(画面上では変化なし)

1. ケアマネログインする(office持っている)
2. ログイン成功後、アイコンクリック予約状況画面へ遷移

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
