### PR TITLE
officeカード お礼と詳細が正しく表示されるように修正

### DIFF
--- a/components/office/officeCard.vue
+++ b/components/office/officeCard.vue
@@ -147,7 +147,7 @@ export default {
     },
     displayComments() {
       return this.office.thank.comments === undefined
-        ? this.office.detail.message
+        ? this.office.thank.message
         : this.office.thank.comments
     },
     listItems() {


### PR DESCRIPTION
## やったこと

- officeカード、詳細とお礼が正しく表示されていなかった箇所修正

- before
[![Image from Gyazo](https://i.gyazo.com/75bd6e41a7784833ff8f1866f89807d3.png)](https://gyazo.com/75bd6e41a7784833ff8f1866f89807d3)
- after
  - お礼が表示されてる　詳細登録されてないとされてないというmsgが表示されている
[![Image from Gyazo](https://i.gyazo.com/67e75945246e1676d04ff78a447430fe.png)](https://gyazo.com/67e75945246e1676d04ff78a447430fe)
  - 詳細表示されている お礼がないと表示されてないというmsgが表示されている
[![Image from Gyazo](https://i.gyazo.com/82083c323567502eaa6320e036db6dd8.png)](https://gyazo.com/82083c323567502eaa6320e036db6dd8)
## やらないこと

- このプルリクでやらないことは何か？（**やらない場合は、いつやるのかを明記する**）

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/office-component-bug
```

### 動作確認 Loom 手順

- 詳細を登録しているオフィスを検索する(ないなら作成する 項目はdetailのみでok) 
- 画像のように、お礼と詳細の項目が表示されている
[![Image from Gyazo](https://i.gyazo.com/82083c323567502eaa6320e036db6dd8.png)](https://gyazo.com/82083c323567502eaa6320e036db6dd8)

- お礼のないオフィスでお礼を作成する(スタッフいないと作成できないのでスタッフがあるオフィスを選ぶ)
- 一覧へ戻って、お礼が表示されていることを確認する
[![Image from Gyazo](https://i.gyazo.com/67e75945246e1676d04ff78a447430fe.png)](https://gyazo.com/67e75945246e1676d04ff78a447430fe)

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
