### PR TITLE
SP版トップページ ロゴクリックしてもトップに遷移しないバグ修正

### DIFF
--- a/layouts/application.vue
+++ b/layouts/application.vue
@@ -97,6 +97,7 @@
                   src="~/assets/images/header-icon.svg"
                   width="157.44"
                   height="28"
+                  @click="topPage"
                 />
               </div>
             </v-toolbar-title>


### PR DESCRIPTION
## やったこと

- SP版トップページ ロゴクリックしてもトップに遷移しないバグ修正

## やらないこと

- なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/set_action-sp_top_page_logo_click
```

### 動作確認 Loom 手順

- カスタマーでログインする
- トップページの画面サイズをスマホサイズ（**iphoneSE 375 x 667**）
- ヘッダーから閲覧履歴などに飛ぶ
- 左上のロゴをクリック
- トップに遷移すれば ✅ 

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
