### PR TITLE
apiのエンドポイント共通化・404対応

### DIFF
--- a/pages/reset-passwords/edit.vue
+++ b/pages/reset-passwords/edit.vue
@@ -57,9 +57,8 @@ export default {
   },
   methods: {
     async resetPassword() {
-      const type = this.type === 'specialist' ? 'specialists/users' : 'customer'
       try {
-        await this.$axios.$put(`${type}/password`, {
+        await this.$axios.$put('reset-password', {
           password: this.password,
           password_confirmation: this.passwordConfirmation,
         })

--- a/pages/reset-passwords/index.vue
+++ b/pages/reset-passwords/index.vue
@@ -73,9 +73,8 @@ export default {
   },
   methods: {
     async applyForPasswordReset() {
-      const type = this.type === 'specialist' ? 'specialists/users' : 'customer'
       try {
-        await this.$axios.$post(`${type}/password`, {
+        await this.$axios.$post('reset-password', {
           email: this.email,
           redirect_url: this.redirectUrl,
         })

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -21,12 +21,12 @@ const catchAPIError = function (store, error) {
       }
       error401and403and422(store, error)
       break
-    /* case 404: TODO パスワードリセット404の対応
-      if (skipErrorCatch(error, ['reset-passwords'])) {
+    case 404:
+      if (skipErrorCatch(error, ['reset-password'])) {
         return
       }
-      // console.dir(response)
-      break */
+      error401and403and422(store, error)
+      break
     case 500:
       error500(store)
       break
@@ -67,6 +67,7 @@ const error401and403and422 = function (store, error) {
   } else {
     msg = error.response.data.errors.full_messages
   }
+
   store.commit('catchErrorMsg/clearMsg')
   store.commit('catchErrorMsg/setMsg', msg)
   store.commit('catchErrorMsg/setType', 'error')


### PR DESCRIPTION
## やったこと

- 404対応
- エンドポイントの共通化の対応

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/password-reset-query-set
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/password-reset-404
```

### 動作確認 Loom 手順

- フロントの`.envファイル`の`PASSWORD_RESET_REDIRECT_URL`を下記のように書き換え
```ruby
PASSWORD_RESET_REDIRECT_URL='https://home-care-navi-v2.herokuapp.com/reset-passwords/edit'
```
- フロントサーバー立ち上げなおし
- パスワードリセットを行う
- メールのリンクをクリックして遷移した画面のulrに必須のqueryがついていることを確認する(client, access-token, expiry, uid) ↓のようなqueryがついていればok
```ruby
https://home-care-navi-v2.herokuapp.com/reset-passwords/edit?type=customer&access-token=VMo7si4BVT0XveN7Nh_tKw&client=W0GKL4jB5R7LZsQhd2GR_Q&client_id=W0GKL4jB5R7LZsQhd2GR_Q&config=default&expiry=1663041249&reset_password=true&token=VMo7si4BVT0XveN7Nh_tKw&uid=mawatari_ayako%40example.net
```
- 遷移先は本番環境なのでここでパスワードリセットしてもパスワードリセット処理は実行されません
- フロントで変更した`.env`ファイルはもとに戻しておいてください

質問ある場合は、コメントに残してください。
説明会の時に回答します!

## 参考になったサイト

- [パスワードリセットオーバーライドした](https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/controllers/devise_token_auth/passwords_controller.rb)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
