### PR TITLE
バグ改修：連動validメッセージ表示

### DIFF
--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -278,7 +278,7 @@
                     @change="detailImage_1Picked"
                   ></v-file-input>
                   <p v-if="inputImageNoComment_1" class="image-text-link-error">
-                    こちらの画像を設定する場合は特徴画像1の説明も設定してください
+                    特徴画像１を登録する場合、特徴画像1の説明は必須となります
                   </p>
                 </v-sheet>
                 <label class="font-color-gray font-weight-black text-caption"
@@ -295,7 +295,7 @@
                   </v-text-field
                 ></label>
                 <p v-if="noImageInputComment_1" class="image-text-link-error">
-                  こちらの説明文を設定する場合は特徴画像1も設定してください
+                  特徴画像1の説明を登録する場合、特徴画像１は必須となります
                 </p>
                 <v-sheet class="pa-3">
                   <div class="d-none d-sm-block">
@@ -337,7 +337,7 @@
                   ></v-file-input>
                 </v-sheet>
                 <p v-if="inputImageNoComment_2" class="image-text-link-error">
-                  こちらの画像を設定する場合は特徴画像2の説明も設定してくだい
+                  特徴画像2を登録する場合、特徴画像2の説明は必須となります
                 </p>
                 <label class="font-color-gray font-weight-black text-caption"
                   >特徴画像2の説明（任意）
@@ -353,7 +353,7 @@
                   </v-text-field
                 ></label>
                 <p v-if="noImageInputComment_2" class="image-text-link-error">
-                  こちらの説明文を設定する場合は特徴画像2も設定してください
+                  特徴画像2の説明を登録する場合、特徴画像2は必須となります
                 </p>
                 <v-form>
                   <label class="font-color-gray font-weight-black text-caption"

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -460,7 +460,7 @@
             x-large
             block
             depressed
-            :disabled="!valid || detail_image_Check"
+            :disabled="!valid || detail_image_Check_1 || detail_image_Check_2"
             color="warning"
             @click="send()"
           >
@@ -603,12 +603,17 @@ export default {
     noImageInputComment_2() {
       return this.detail_image_2 === null && this.comment_2 !== ''
     },
-    detail_image_Check() {
+    detail_image_Check_1() {
       if (this.detail_image_1 !== null && this.comment_1 === '') {
         return true
       } else if (this.detail_image_1 === null && this.comment_1 !== '') {
         return true
-      } else if (this.detail_image_2 !== null && this.comment_2 === '') {
+      } else {
+        return false
+      }
+    },
+    detail_image_Check_2() {
+      if (this.detail_image_2 !== null && this.comment_2 === '') {
         return true
       } else if (this.detail_image_2 === null && this.comment_2 !== '') {
         return true

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -460,7 +460,7 @@
             x-large
             block
             depressed
-            :disabled="!valid || detail_image_Check_1"
+            :disabled="!valid || detail_image_Check"
             color="warning"
             @click="send()"
           >
@@ -603,17 +603,12 @@ export default {
     noImageInputComment_2() {
       return this.detail_image_2 === null && this.comment_2 !== ''
     },
-    detail_image_Check_1() {
+    detail_image_Check() {
       if (this.detail_image_1 !== null && this.comment_1 === '') {
         return true
       } else if (this.detail_image_1 === null && this.comment_1 !== '') {
         return true
-      } else {
-        return false
-      }
-    },
-    detail_image_Check_2() {
-      if (this.detail_image_Check_2 !== null && this.comment_2 === '') {
+      } else if (this.detail_image_2 !== null && this.comment_2 === '') {
         return true
       } else if (this.detail_image_2 === null && this.comment_2 !== '') {
         return true

--- a/pages/specialists/office/new.vue
+++ b/pages/specialists/office/new.vue
@@ -277,6 +277,9 @@
                     class="detail-image-form"
                     @change="detailImage_1Picked"
                   ></v-file-input>
+                  <p v-if="inputImageNoComment_1" class="image-text-link-error">
+                    こちらの画像を設定する場合は特徴画像1の説明も設定してください
+                  </p>
                 </v-sheet>
                 <label class="font-color-gray font-weight-black text-caption"
                   >特徴画像1の説明（任意）
@@ -291,6 +294,9 @@
                   >
                   </v-text-field
                 ></label>
+                <p v-if="noImageInputComment_1" class="image-text-link-error">
+                  こちらの説明文を設定する場合は特徴画像1も設定してください
+                </p>
                 <v-sheet class="pa-3">
                   <div class="d-none d-sm-block">
                     <v-avatar
@@ -330,6 +336,9 @@
                     @change="detailImage_2Picked"
                   ></v-file-input>
                 </v-sheet>
+                <p v-if="inputImageNoComment_2" class="image-text-link-error">
+                  こちらの画像を設定する場合は特徴画像2の説明も設定してくだい
+                </p>
                 <label class="font-color-gray font-weight-black text-caption"
                   >特徴画像2の説明（任意）
                   <v-text-field
@@ -343,6 +352,9 @@
                   >
                   </v-text-field
                 ></label>
+                <p v-if="noImageInputComment_2" class="image-text-link-error">
+                  こちらの説明文を設定する場合は特徴画像2も設定してください
+                </p>
                 <v-form>
                   <label class="font-color-gray font-weight-black text-caption"
                     >開設年月（任意）
@@ -448,7 +460,7 @@
             x-large
             block
             depressed
-            :disabled="!valid"
+            :disabled="!valid || detail_image_Check_1"
             color="warning"
             @click="send()"
           >
@@ -577,6 +589,38 @@ export default {
       valid: false,
       isShow: true,
     }
+  },
+  computed: {
+    inputImageNoComment_1() {
+      return this.detail_image_1 !== null && this.comment_1 === ''
+    },
+    inputImageNoComment_2() {
+      return this.detail_image_2 !== null && this.comment_2 === ''
+    },
+    noImageInputComment_1() {
+      return this.detail_image_1 === null && this.comment_1 !== ''
+    },
+    noImageInputComment_2() {
+      return this.detail_image_2 === null && this.comment_2 !== ''
+    },
+    detail_image_Check_1() {
+      if (this.detail_image_1 !== null && this.comment_1 === '') {
+        return true
+      } else if (this.detail_image_1 === null && this.comment_1 !== '') {
+        return true
+      } else {
+        return false
+      }
+    },
+    detail_image_Check_2() {
+      if (this.detail_image_Check_2 !== null && this.comment_2 === '') {
+        return true
+      } else if (this.detail_image_2 === null && this.comment_2 !== '') {
+        return true
+      } else {
+        return false
+      }
+    },
   },
   watch: {
     selected: {
@@ -711,6 +755,11 @@ input[type='checkbox'] {
 }
 
 .holiday-error-text {
+  color: red;
+  text-align: center;
+}
+
+.image-text-link-error {
   color: red;
   text-align: center;
 }

--- a/pages/specialists/users/new.vue
+++ b/pages/specialists/users/new.vue
@@ -241,7 +241,7 @@ export default {
     },
   },
   watch: {
-    // form.phene_numberの値がusersテーブルとofficesテーブルの被りがないかチェック
+    // form.phone_numberの値がusersテーブルとofficesテーブルの被りがないかチェック
     // 被りがあったら、'登録済みの電話番号です。'を表示 エラーメッセージはapiのレスポンスを使用している
     async 'form.phone_number'() {
       // form.phone_numberの値が変化したらだたちにfalseにする

--- a/pages/users/new.vue
+++ b/pages/users/new.vue
@@ -243,7 +243,7 @@ export default {
     },
   },
   watch: {
-    // form.phene_numberの値がusersテーブルとofficesテーブルの被りがないかチェック
+    // form.phone_numberの値がusersテーブルとofficesテーブルの被りがないかチェック
     // 被りがあったら、'登録済みの電話番号です。'を表示 エラーメッセージはapiのレスポンスを使用している
     async 'form.phone_number'() {
       // form.phone_numberの値が変化したらだたちにfalseにする


### PR DESCRIPTION
## やったこと
＜バグ改修＞
- 事業所登録ページ：（画像orテキスト）片方入力あるなら、片方も必須になる
　●エラーメッセージの表示
　●バリデーション（送信ボタンのON / OFF）
- typo一部修正
## やらないこと
なし

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/office-image-valids
```

### 動作確認 Loom 手順

- 事業所登録フォームでバリデーションの設定確認
- 必須項目に入力してから、以下の項目を確認する。
　特徴画像① / 特徴画像①の説明文
　特徴画像② / 特徴画像②の説明文

エラー条件
```ruby
『特徴画像１』を入れた時、『特徴画像１の説明』が空
　登録できない→　エラー：特徴画像１を登録する場合、特徴画像1の説明は必須となります

『特徴画像１の説明』を入れた時、『特徴画像１』が空
　登録できない→　エラー：特徴画像1の説明を登録する場合、特徴画像１は必須となります
〜〜〜
特徴画像２ / 特徴画像２の説明も同様の条件
〜〜〜
```
メッセージ表示 と 送信ボタンON / OFF を確認する。

### 確認書類

**URL は該当のものに変えること**  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)

## 参考になったサイト

- [Vuetify: custom validator check failed for prop "value"](https://qiita.com/Sicut_study/items/ed41eb541cb6a8eef410)
- [vuetify の v-input-file をリセットする方法](https://newdevzone.com/posts/how-to-reset-vuetifys-v-input-file)
- [v-file-inputでファイル選択をキャンセルするとv-modelが空になってしまう問題に対処してみる](https://qiita.com/yusukeasari/items/73e7562888202a7f70aa)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
APIのプルリクとセットで確認する場合は、APIプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] ファイル名・変数名・メソッド名は適切か
- [コーディングの命名規則一覧](https://murashun.jp/article/programming/naming-conventions.html)
- [x] ファイル名・変数名・メソッド名は直感でわかりやすいものになっているか
- [変数名の付け方をまとめてみた](https://zenn.dev/naoki_oshiumi/articles/aad7e1b3719fad)
- [x] バリデーションは仕様に沿っているか
- [x] バリデーションメッセージは適切か
- [x] ページ内の文章に違和感はないか。統一感はあるか

```javascript
NG例1　統一感のないアラートメッセージ
- アラート1
ログインをする必要があります
- アラート2
ログインをしてください
NG例2　書き言葉になっていない
- メールを送りました
- ログインしたら利用できます
OK
- メールを送信しました
- ログインをする必要があります
```
